### PR TITLE
v0.9.1-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.9.1-alpha.3] - 2024-03-18
+
+### Changed
+
+- Upgraded `oxrdf`, `oxttl`, and `rdf-canon` dependencies
+
 ## [0.9.1-alpha.2] - 2024-03-18
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ serde = "1.0"
 serde_cbor = "0.11"
 serde_with = "3.2"
 
-oxrdf = "0.2.0-alpha.1"
-oxttl = "0.1.0-alpha.1"
+oxrdf = "0.2.0-alpha.3"
+oxttl = "0.1.0-alpha.3"
 oxsdatatypes = "0.2.0-alpha.1"
 oxiri = "0.2.3-alpha.1"
 
-rdf-canon = "0.15.0-alpha.2"
+rdf-canon = "0.15.0-alpha.5"
 
 proof_system = { version = "0.24", default-features = false }
 bbs_plus = { version = "0.18", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdf-proofs"
-version = "0.9.1-alpha.2"
+version = "0.9.1-alpha.3"
 edition = "2021"
 authors = ["yamdan"]
 license = "MIT"

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ pub enum RDFProofsError {
     Multibase(multibase::Error),
     MissingInputToDeriveProof,
     IriParse(oxiri::IriParseError),
-    TtlParse(oxttl::ParseError),
+    TtlParse(oxttl::TurtleParseError),
     TtlTermParse(String),
     InvalidDeanonMapFormat(String),
     VCWithoutProofValue,
@@ -247,8 +247,8 @@ impl From<proof_system::prelude::ProofSystemError> for RDFProofsError {
     }
 }
 
-impl From<oxttl::ParseError> for RDFProofsError {
-    fn from(e: oxttl::ParseError) -> Self {
+impl From<oxttl::TurtleParseError> for RDFProofsError {
+    fn from(e: oxttl::TurtleParseError) -> Self {
         Self::TtlParse(e)
     }
 }


### PR DESCRIPTION
### Changed

- Upgraded `oxrdf`, `oxttl`, and `rdf-canon` dependencies
