### PR TITLE
v0.10.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.10.0-alpha.0] - 2024-08-23
+
+### Changed
+
+- **BREAKING** Changed key encoding format from `base64url` to `base58btc` + `multicodecs`
+- **BREAKING** Replaced PPID representation with `did:key` instead of `ppid:`
+- **BREAKING** Upgraded `docknetwork/crypto` libraries (`proof_system`, `bbs_plus`, `dock_crypto_utils`, `legogroth16`) resulting in breaking changes in several cryptographic objects
+- Updated `oxrdf`, `oxttl`, `rdf-canon`, and other dependencies
+
+### Fixed
+
+- Separated zk-SNARK proving keys and verifying keys in several test cases
+
 ## [0.9.1-alpha.4] - 2024-03-18
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,12 @@ serde = "1.0"
 serde_cbor = "0.11"
 serde_with = "3.9"
 
-oxrdf = "0.2.0-alpha.3"
-oxttl = "0.1.0-alpha.3"
+oxrdf = "0.2.0-alpha.6"
+oxttl = "0.1.0-alpha.7"
 oxsdatatypes = "0.2.0-alpha.1"
 oxiri = "0.2.3-alpha.1"
 
-rdf-canon = "0.15.0-alpha.5"
+rdf-canon = "0.15.0-alpha.6"
 
 proof_system = { version = "0.31", default-features = false }
 bbs_plus = { version = "0.22", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdf-proofs"
-version = "0.9.1-alpha.4"
+version = "0.10.0-alpha.0"
 edition = "2021"
 authors = ["yamdan"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ wasmer-sys = ["proof_system/wasmer-sys"]
 chrono = "0.4"
 regex = "1.9"
 multibase = "0.9"
+unsigned-varint = "0.8"
 
 serde = "1.0"
 serde_cbor = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ wasmer-sys = ["proof_system/wasmer-sys"]
 
 [dependencies]
 chrono = "0.4"
-regex = "1.9"
+regex = "1.10"
 multibase = "0.9"
 unsigned-varint = "0.8"
 
 serde = "1.0"
 serde_cbor = "0.11"
-serde_with = "3.2"
+serde_with = "3.9"
 
 oxrdf = "0.2.0-alpha.3"
 oxttl = "0.1.0-alpha.3"
@@ -34,10 +34,10 @@ oxiri = "0.2.3-alpha.1"
 
 rdf-canon = "0.15.0-alpha.5"
 
-proof_system = { version = "0.24", default-features = false }
-bbs_plus = { version = "0.18", default-features = false }
-dock_crypto_utils = { version = "0.16", default-features = false }
-legogroth16 = { version = "0.11", default-features = false, features = [
+proof_system = { version = "0.31", default-features = false }
+bbs_plus = { version = "0.22", default-features = false }
+dock_crypto_utils = { version = "0.20", default-features = false }
+legogroth16 = { version = "0.15", default-features = false, features = [
     "circom",
 ] }
 ark-ff = { version = "0.4", default-features = false }

--- a/src/blind_signature.rs
+++ b/src/blind_signature.rs
@@ -363,26 +363,26 @@ mod tests {
     <did:example:issuer0> <https://w3id.org/security#verificationMethod> <did:example:issuer0#bls12_381-g2-pub001> .
     <did:example:issuer0#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
     <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer0> .
-    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "uekl-7abY7R84yTJEJ6JRqYohXxPZPDoTinJ7XCcBkmk" .
-    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "ukiiQxfsSfV0E2QyBlnHTK2MThnd7_-Fyf6u76BUd24uxoDF4UjnXtxUo8b82iuPZBOa8BXd1NpE20x3Rfde9udcd8P8nPVLr80Xh6WLgI9SYR6piNzbHhEVIfgd_Vo9P" .
+    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z4893E1L7AeYfqaduUdLYgcxefWAah8gJB8RhPi7JHQkdRbe" .
+    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC77BjGcGDVWfBdgzqwzp3uuWkoWuRMe8pnx4dkncia5t9LKHVt96BPGBizeSU7BKiV35h1tsuVwHUVt4arZuckxGCb2tTsB3fsY66mQNs5Bwoac2w2iyYFe8uenBUYdAiveEr" .
     # issuer1
     <did:example:issuer1> <https://w3id.org/security#verificationMethod> <did:example:issuer1#bls12_381-g2-pub001> .
     <did:example:issuer1#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
     <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer1> .
-    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "uQkpZn0SW42c2tlYa0IIFXyabAYHbwc0z3l_GvXQbWSg" .
-    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "usFM3CcvBMl_Dg5ixhQkHKGdqzY3GU9Uck6lj2i8vpbzLFOiZnjDNOpsItrkbNf2iCku-SZu5kO3nbLis-fuRhz_QwFcKw9IBpbPRPwXNQTX3zzcFsoNzs_wo8tkLQlcS" .
+    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z488yTRFj1e7W6s6MVN6iYm6taiNByQwSCg2XwgEJvAcXr15" .
+    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC7HaSjNELSGG8QnYdMvNurgfWfdGNo1Znqds6CoYQ24qKKWogiLtKWPoCLJapEYdKAMN9r6bdF9MeNrfV3fhUzkKwrfUewD5yVhwSVpM4tjv87YVgWGRTUuesxf7scabbPAnD" .
     # issuer2
     <did:example:issuer2> <https://w3id.org/security#verificationMethod> <did:example:issuer2#bls12_381-g2-pub001> .
     <did:example:issuer2#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
     <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer2> .
-    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "u4nmBsiSwvHj7i_gBu1L6Cug0OXXhVPF6NWLfkQbCZiU" .
-    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "uo_yMZWlZwQzLqEe6hEsORbsV5cSHQEQHNI0EOe_eUJdHsgCRxtpWMcxxcdshH5pAAUxt_ni6_cQCud3CdMcjAUN8yOvzhuzeIW_H-Dyncdrc3w0f2WxdH3oRcnvPTwrb" .
+    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z489AEiC5VbeLmVZxokiJYkXNZrMza9eCiPZ51ekgcV9mNvG" .
+    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC7DKvfSfydgg48FpP53HgsLfWrVHfrmUXbwvw8AnSgW1JiA5741mwe3hpMNNRMYh3BgR9ebxvGAxPxFhr8F3jQHZANqb3if2MycjQN3ZBSWP3aGoRyat294icdVMDhTqoKXeJ" .
     # issuer3
     <did:example:issuer3> <https://w3id.org/security#verificationMethod> <did:example:issuer3#bls12_381-g2-pub001> .
     <did:example:issuer3#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
     <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer3> .
-    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "uH1yGFG6C1pJd_N45wkOPrSNdvILdLm0c_0AXXRDGZy8" .
-    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "uidSE_Urr5MFE4SoqV3TZTBHPHM-tkpdRhBPrYeIbsudglVV_cddyEstHJOmSkfPOFsvEuA9qtWjFNpBebVSS4DPxBfNNWESSCz_vrnH62hbfpWdJSFR8YbqjborvpgM6" .
+    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z488w754KqucDkNxCWCoi5DkH6pvEt6aNZNYYYoKmDDx8m5G" .
+    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC74KLKQtdApVyY3EbAZfiW6A7HdwSZVLsBF2vs5512YwNWs5PRYiqavzWLoiAq6UcKLv6RAnUM9Y117Pg4LayaBMa9euz23C2TDtBq8QuhpbDRDqsjUxLS5S9ruWRk71SEo69" .
     "#;
 
     #[test]

--- a/src/blind_signature.rs
+++ b/src/blind_signature.rs
@@ -298,7 +298,7 @@ pub fn unblind_string(
     proof: &str,
     blinding: &str,
 ) -> Result<String, RDFProofsError> {
-    let blinding: Fr = multibase_to_ark(blinding)?;
+    let blinding = multibase_to_ark(blinding)?;
     let mut blinded_credential = get_vc_from_ntriples(document, proof)?;
     let proof_value = unblind_core(&blinded_credential, &blinding)?;
     blinded_credential.replace_proof_value(proof_value)?;

--- a/src/common.rs
+++ b/src/common.rs
@@ -311,7 +311,7 @@ pub fn hash_term_to_field(
             let datetime = date
                 .and_hms_opt(0, 0, 0)
                 .ok_or(RDFProofsError::InvalidDateTime(v.value().to_string()))?;
-            let timestamp = datetime.timestamp();
+            let timestamp = datetime.and_utc().timestamp();
             Fr::try_from(timestamp)
                 .map_err(|_| RDFProofsError::InvalidDateTime(v.value().to_string()))
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -36,7 +36,7 @@ use proof_system::{
     prelude::R1CSCircomWitness as R1CSCircomWitnessOrig,
     proof::Proof as ProofOrig,
     statement::{
-        bbs_plus::PoKBBSSignatureG1 as PoKBBSSignatureG1Stmt,
+        bbs_plus::{PoKBBSSignatureG1Prover, PoKBBSSignatureG1Verifier},
         ped_comm::PedersenCommitment,
         r1cs_legogroth16::{ProvingKey as ProvingKeyOrig, VerifyingKey as VerifyingKeyOrig},
         Statements as StatementsOrig,
@@ -53,8 +53,8 @@ use std::{
 use unsigned_varint;
 
 pub type Fr = <Bls12_381 as Pairing>::ScalarField;
-pub type Proof = ProofOrig<Bls12_381, G1Affine>;
-pub type Statements = StatementsOrig<Bls12_381, <Bls12_381 as Pairing>::G1Affine>;
+pub type Proof = ProofOrig<Bls12_381>;
+pub type Statements = StatementsOrig<Bls12_381>;
 pub type BBSPlusHash = Blake2b512;
 pub type BBSPlusDefaultFieldHasher = DefaultFieldHasher<BBSPlusHash>;
 pub type BBSPlusParams = SignatureParamsG1<Bls12_381>;
@@ -62,7 +62,8 @@ pub type BBSPlusKeypair = KeypairG2<Bls12_381>;
 pub type BBSPlusSecretKey = SecretKey<Fr>;
 pub type BBSPlusPublicKey = PublicKeyG2<Bls12_381>;
 pub type BBSPlusSignature = SignatureG1<Bls12_381>;
-pub type PoKBBSPlusStmt<E> = PoKBBSSignatureG1Stmt<E>;
+pub type PoKBBSPlusStmtProver<E> = PoKBBSSignatureG1Prover<E>;
+pub type PoKBBSPlusStmtVerifier<E> = PoKBBSSignatureG1Verifier<E>;
 pub type PoKBBSPlusWit<E> = PoKBBSSignatureG1Wit<E>;
 pub type PedersenCommitmentStmt = PedersenCommitment<G1Affine>;
 pub type ProvingKey = ProvingKeyOrig<Bls12_381>;

--- a/src/common.rs
+++ b/src/common.rs
@@ -158,14 +158,7 @@ pub fn ark_to_base64url<A: CanonicalSerialize>(ark: &A) -> Result<String, RDFPro
     ark_to_multibase(Base::Base64Url, ark)
 }
 
-pub fn ark_to_base64url_with_codec<A: CanonicalSerialize>(
-    ark: &A,
-    codec: Multicodec,
-) -> Result<String, RDFProofsError> {
-    ark_to_multibase_with_codec(Base::Base64Url, Some(codec), ark)
-}
-
-pub fn ark_to_base58btc_with_codec<A: CanonicalSerialize>(
+pub fn ark_to_base58btc<A: CanonicalSerialize>(
     ark: &A,
     codec: Multicodec,
 ) -> Result<String, RDFProofsError> {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -7,4 +7,4 @@ pub const MAP_TO_SCALAR_AS_HASH_DST: &[u8; 32] = b"BBS_*_MAP_MSG_TO_SCALAR_AS_HA
 pub const DELIMITER: &[u8; 13] = b"__DELIMITER__"; // TODO: fix it later
 pub const BLIND_SIG_REQUEST_CONTEXT: &[u8; 23] = b"BBS_*_BLIND_SIG_REQUEST"; // TODO: fix it later
 pub const PPID_SEED: &[u8; 15] = b"BBS_*_PPID_SEED"; // TODO: fix it later
-pub const PPID_PREFIX: &str = "https://zkp-ld.org/.well-known/genid/"; // TODO: fix it later
+pub const DID_KEY_PREFIX: &str = "did:key:";

--- a/src/derive_proof.rs
+++ b/src/derive_proof.rs
@@ -1,11 +1,10 @@
 use super::constants::CRYPTOSUITE_PROOF;
 use crate::{
-    ark_to_base64url,
     blind_signature::{blind_verify, BlindSignRequest, BlindSignRequestString},
     common::{
-        canonicalize_graph, generate_proof_spec_context, get_delimiter, get_graph_from_ntriples,
-        get_hasher, get_term_from_string, get_vc_from_ntriples, hash_byte_to_field,
-        hash_term_to_field, is_nym, multibase_to_ark, randomize_bnodes,
+        ark_to_base64url, canonicalize_graph, generate_proof_spec_context, get_delimiter,
+        get_graph_from_ntriples, get_hasher, get_term_from_string, get_vc_from_ntriples,
+        hash_byte_to_field, hash_term_to_field, is_nym, multibase_to_ark, randomize_bnodes,
         randomize_bnodes_in_vc_pairs, read_private_var_list, read_public_var_list,
         reorder_vc_triples, BBSPlusDefaultFieldHasher, BBSPlusHash, BBSPlusPublicKey,
         BBSPlusSignature, Fr, PedersenCommitmentStmt, PoKBBSPlusStmt, PoKBBSPlusWit, Proof,

--- a/src/derive_proof.rs
+++ b/src/derive_proof.rs
@@ -1413,26 +1413,26 @@ mod tests {
     <did:example:issuer0> <https://w3id.org/security#verificationMethod> <did:example:issuer0#bls12_381-g2-pub001> .
     <did:example:issuer0#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
     <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer0> .
-    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "uekl-7abY7R84yTJEJ6JRqYohXxPZPDoTinJ7XCcBkmk" .
-    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "ukiiQxfsSfV0E2QyBlnHTK2MThnd7_-Fyf6u76BUd24uxoDF4UjnXtxUo8b82iuPZBOa8BXd1NpE20x3Rfde9udcd8P8nPVLr80Xh6WLgI9SYR6piNzbHhEVIfgd_Vo9P" .
+    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z4893E1L7AeYfqaduUdLYgcxefWAah8gJB8RhPi7JHQkdRbe" .
+    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC77BjGcGDVWfBdgzqwzp3uuWkoWuRMe8pnx4dkncia5t9LKHVt96BPGBizeSU7BKiV35h1tsuVwHUVt4arZuckxGCb2tTsB3fsY66mQNs5Bwoac2w2iyYFe8uenBUYdAiveEr" .
     # issuer1
     <did:example:issuer1> <https://w3id.org/security#verificationMethod> <did:example:issuer1#bls12_381-g2-pub001> .
     <did:example:issuer1#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
     <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer1> .
-    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "uQkpZn0SW42c2tlYa0IIFXyabAYHbwc0z3l_GvXQbWSg" .
-    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "usFM3CcvBMl_Dg5ixhQkHKGdqzY3GU9Uck6lj2i8vpbzLFOiZnjDNOpsItrkbNf2iCku-SZu5kO3nbLis-fuRhz_QwFcKw9IBpbPRPwXNQTX3zzcFsoNzs_wo8tkLQlcS" .
+    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z488yTRFj1e7W6s6MVN6iYm6taiNByQwSCg2XwgEJvAcXr15" .
+    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC7HaSjNELSGG8QnYdMvNurgfWfdGNo1Znqds6CoYQ24qKKWogiLtKWPoCLJapEYdKAMN9r6bdF9MeNrfV3fhUzkKwrfUewD5yVhwSVpM4tjv87YVgWGRTUuesxf7scabbPAnD" .
     # issuer2
     <did:example:issuer2> <https://w3id.org/security#verificationMethod> <did:example:issuer2#bls12_381-g2-pub001> .
     <did:example:issuer2#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
     <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer2> .
-    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "u4nmBsiSwvHj7i_gBu1L6Cug0OXXhVPF6NWLfkQbCZiU" .
-    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "uo_yMZWlZwQzLqEe6hEsORbsV5cSHQEQHNI0EOe_eUJdHsgCRxtpWMcxxcdshH5pAAUxt_ni6_cQCud3CdMcjAUN8yOvzhuzeIW_H-Dyncdrc3w0f2WxdH3oRcnvPTwrb" .
+    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z489AEiC5VbeLmVZxokiJYkXNZrMza9eCiPZ51ekgcV9mNvG" .
+    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC7DKvfSfydgg48FpP53HgsLfWrVHfrmUXbwvw8AnSgW1JiA5741mwe3hpMNNRMYh3BgR9ebxvGAxPxFhr8F3jQHZANqb3if2MycjQN3ZBSWP3aGoRyat294icdVMDhTqoKXeJ" .
     # issuer3
     <did:example:issuer3> <https://w3id.org/security#verificationMethod> <did:example:issuer3#bls12_381-g2-pub001> .
     <did:example:issuer3#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
     <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer3> .
-    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "uH1yGFG6C1pJd_N45wkOPrSNdvILdLm0c_0AXXRDGZy8" .
-    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "uidSE_Urr5MFE4SoqV3TZTBHPHM-tkpdRhBPrYeIbsudglVV_cddyEstHJOmSkfPOFsvEuA9qtWjFNpBebVSS4DPxBfNNWESSCz_vrnH62hbfpWdJSFR8YbqjborvpgM6" .
+    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z488w754KqucDkNxCWCoi5DkH6pvEt6aNZNYYYoKmDDx8m5G" .
+    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC74KLKQtdApVyY3EbAZfiW6A7HdwSZVLsBF2vs5512YwNWs5PRYiqavzWLoiAq6UcKLv6RAnUM9Y117Pg4LayaBMa9euz23C2TDtBq8QuhpbDRDqsjUxLS5S9ruWRk71SEo69" .
     "#;
 
     const VC_1: &str = r#"

--- a/src/derive_proof.rs
+++ b/src/derive_proof.rs
@@ -607,7 +607,7 @@ fn build_vp(
             ));
         }
         (Some(ppid), _) => {
-            let vp_holder_id = NamedNode::new(ppid.try_into_multibase()?)?;
+            let vp_holder_id = NamedNode::new(ppid.try_into_did_key()?)?;
             vp.insert(QuadRef::new(
                 &vp_id,
                 HOLDER,

--- a/src/derive_proof.rs
+++ b/src/derive_proof.rs
@@ -7,7 +7,7 @@ use crate::{
         hash_byte_to_field, hash_term_to_field, is_nym, multibase_to_ark, randomize_bnodes,
         randomize_bnodes_in_vc_pairs, read_private_var_list, read_public_var_list,
         reorder_vc_triples, BBSPlusDefaultFieldHasher, BBSPlusHash, BBSPlusPublicKey,
-        BBSPlusSignature, Fr, PedersenCommitmentStmt, PoKBBSPlusStmt, PoKBBSPlusWit, Proof,
+        BBSPlusSignature, Fr, PedersenCommitmentStmt, PoKBBSPlusStmtProver, PoKBBSPlusWit, Proof,
         ProofWithIndexMap, R1CSCircomWitness, StatementIndexMap, Statements,
     },
     context::{
@@ -1009,12 +1009,11 @@ fn derive_proof_value<R: RngCore>(
     // build statements
     let mut statements = Statements::new();
     // statements for BBS+ signatures
-    for (DisclosedAndUndisclosedTerms { disclosed, .. }, (params, public_key)) in
+    for (DisclosedAndUndisclosedTerms { disclosed, .. }, (params, _public_key)) in
         disclosed_and_undisclosed_terms.iter().zip(params_and_pks)
     {
-        statements.add(PoKBBSPlusStmt::new_statement_from_params(
+        statements.add(PoKBBSPlusStmtProver::new_statement_from_params(
             params.clone(),
-            public_key,
             disclosed.clone(),
         ));
     }
@@ -1556,23 +1555,23 @@ mod tests {
         get_deanon_map_from_string(&get_example_deanon_map_string()).unwrap()
     }
     const VP: &str = r#"
-    _:c14n1 <http://purl.org/dc/terms/created> "2023-02-09T09:35:07Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:c14n10 .
-    _:c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#DataIntegrityProof> _:c14n10 .
-    _:c14n1 <https://w3id.org/security#cryptosuite> "bbs-termwise-signature-2023" _:c14n10 .
-    _:c14n1 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> _:c14n10 .
-    _:c14n1 <https://w3id.org/security#verificationMethod> <did:example:issuer0#bls12_381-g2-pub001> _:c14n10 .
-    _:c14n11 <http://purl.org/dc/terms/created> "2023-10-06T05:40:05.941640167Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:c14n13 .
-    _:c14n11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#DataIntegrityProof> _:c14n13 .
-    _:c14n11 <https://w3id.org/security#challenge> "abcde" _:c14n13 .
-    _:c14n11 <https://w3id.org/security#cryptosuite> "bbs-termwise-proof-2023" _:c14n13 .
-    _:c14n11 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#authenticationMethod> _:c14n13 .
-    _:c14n11 <https://w3id.org/security#proofValue> "uomFhWQnaAgAAAAAAAAAAlWj7ySOnU5mw_rG271EltSGHfh0Sabj6_FBXzZ7GBT7TTXM-OJk2y-UjU8hAYyS9p5SkDSPYysuFjUy9RUNu4ypsNdZrRJX2E3TmTg-186q3jvPKExzchRPg7LrE6pWeqzMXck8jrsaUR1_zIsH6KKuTO5gnDEOV4Ufg8zCm7nDLetSoflGoX0d-AUrr9-C_j1WOnJ0-lOnlLr3Mg5hOjxDktjaDvUdwDJ36rFx7agxBvtUKa7deW1Ta-Vq1vFiiAgAAAAAAAACTBwTiEdk00-BvIIfqz8oDk2xDYnTLtUDSu6P0xdL0RjQuKBHV6xaVhb5qoBYP-IdGKx2-2Sk21iHIjrVlQFBup830cauPb0nhTDonFpZRwL7ncq9hXu62basWvqFM3ThJWXiTXss4OpuJW5D0E5h6JQAAAAAAAAB-w7b_iVOFQAQGHgFpp06QV6gwCTxWfLJyxKxKSK-kHpm0wTrncrlMfDmqvHqaHWlcXvv6p7dTHnX0tJLWYC9XUt2I6oyQBKKHQlBI7ZDXkk0Xq9P7QGXrH48bcAW7dTbHdgGgIIBxJ3n8mg1zvsidRWNMNUJx7nHIWxKWIRe5BGqk0y5xBZvij7h_8R64Vw4RfbjtajslQPUN0fiu3s0qP0Iq0VyjWycJ6uAn8i4kZWNWbafJLH8ki8rz_H_o3zC0n0S_-meUXC7Ok2cVmKmcZrZuC-sjgMLdJbVjhqWUD1LdiOqMkASih0JQSO2Q15JNF6vT-0Bl6x-PG3AFu3U2R3eQBscDGEj2SejHCKIW5AQ3vI2u81WOkaojzcsfMR5S3YjqjJAEoodCUEjtkNeSTRer0_tAZesfjxtwBbt1NlltLFFHMcT568va2232ixBc7DF1IviaZJdNvtrU1nxqWW0sUUcxxPnry9rbbfaLEFzsMXUi-Jpkl02-2tTWfGpS3YjqjJAEoodCUEjtkNeSTRer0_tAZesfjxtwBbt1NlltLFFHMcT568va2232ixBc7DF1IviaZJdNvtrU1nxqWW0sUUcxxPnry9rbbfaLEFzsMXUi-Jpkl02-2tTWfGpZbSxRRzHE-evL2ttt9osQXOwxdSL4mmSXTb7a1NZ8anaD_nngpqe5xaQdji-u3evtHCq1bi56QEEZ6eyhzJhQhV79oieifauuxhKLxl3re4PJGFwyCXpXH6Bgi7eedVhKPDD2T3YTIj22AH4inhAyV368j4d3voLJAa4inSwSXUd3kAbHAxhI9knoxwiiFuQEN7yNrvNVjpGqI83LHzEe17WRQdZOAXg-5RYkYZm1ubixq0p0HoNmrqa-L4hCSjEg-SkiGOJYUfBxFAgkYTauH2E2FLz5_NHR4g0mxD2_NcVmZ1okq1eLeIdzUV9RPd4cUbr5uiGObyTu2miM3SsUboOemDnsRSTr7yilMe1x8WK00oIqAJ3tLt71sr2fjSjdAXrIJwtaz3pK0--RrrgOzC2OWjzZWOna0i5WVnhcZZ_SUYwus1fQv3H5VCsXgIA0Sztj5kM0msSkvOQ9sc4bx3YBoCCAcSd5_JoNc77InUVjTDVCce5xyFsSliEXuQRUD-bXOni6wTd1ZJKGXVsu3cDKGrwRcMLtUcLCmo-bCLW73RuCJOGzemtQ-WQtWEtPjfuwiuVWJkV5o152B1BpBgNslfYVji5qEQYcG9iz0suNjVlTC8mcKN4vDspNBW71xFFH-CBvYGoSHgKZ3l0tIJylcX5FMV_FjZO03bLqO8d2AaAggHEnefyaDXO-yJ1FY0w1QnHucchbEpYhF7kELS0TeuolCiEnceAsJagqrgL7AE3FaIpDybD_b6xVaFstLRN66iUKISdx4CwlqCquAvsATcVoikPJsP9vrFVoWy0tE3rqJQohJ3HgLCWoKq4C-wBNxWiKQ8mw_2-sVWhbLS0TeuolCiEnceAsJagqrgL7AE3FaIpDybD_b6xVaFstLRN66iUKISdx4CwlqCquAvsATcVoikPJsP9vrFVoWwCMUROvw7h9P0TgM_oleY-MmLKq9MTn6Y29NKPvmCbprfIx7f4jMu8SRN84CZ0fIv6vvzRo0BC2b_XFb218o1weMHOr8tTs_YfpnJa2qoB0WmgC5Z86ol9FQqGUYi8WVCixy-FMlRZ6nwjJm_4gCSPEKeFVbmUwkqR79KdKDvuMkmrzSX20mYUp1fD6TgghZk2PRSnarn64FqMNRlkwc2K0P30L2iySXPeJEqAUf8TUekHwtVLTyDz_a9Obmz9lYuwCAAAAAAAAAOlK1niDJgDT9pxIwsMeCg3yNSt7nzQ_Ja30N2HYcts0K3EQ_3v04hCcZNINbmYwTZ98XSwMgURCHZaIV-7RvQeiuAl3770_97VvG7-bLPJj35GhJmUwK8Tbw_xBFoMz9yWTIew6ivMP3F-9W2hCyzQVAAAAAAAAAGNy0ZdMnEafcDVeEYYXTavNQsN_5yO8taRWovPJyGUU0quwoJjxTyu_wstf4jKhU32wUodzmFoPOL_qMVLX-hXbLtdBit55MNFE2mgjaOWUWAbk0RVpQrdGXSAzxXnvJ8t3NM6QHw22JEN1L_fCE1C369SkBPsAlRffB8eW8IJrw05KiuEou1_vvDGtEJnbLwX1Orps8mkJQVQ-ZM6BVw7RSvcFFAs3syJC3iO8smoCzr3qK9ACRjA7azFlBNONcbKyqbOczr0k86QWPPuYY7CjAXg73OszTc4SVhs4_oxaKnoln7pNO2VB0NjFbn2mrcrRFc_hJlLnilmo4Uf0kiZUD-bXOni6wTd1ZJKGXVsu3cDKGrwRcMLtUcLCmo-bCFQP5tc6eLrBN3VkkoZdWy7dwMoavBFwwu1RwsKaj5sICvra712P-6jgiuZixbofwrWQdF_3NrtGO6QFRbq7YB4K-trvXY_7qOCK5mLFuh_CtZB0X_c2u0Y7pAVFurtgHlQP5tc6eLrBN3VkkoZdWy7dwMoavBFwwu1RwsKaj5sICvra712P-6jgiuZixbofwrWQdF_3NrtGO6QFRbq7YB4K-trvXY_7qOCK5mLFuh_CtZB0X_c2u0Y7pAVFurtgHgr62u9dj_uo4IrmYsW6H8K1kHRf9za7RjukBUW6u2AeYUx4jiPSsMEUawCLAAqtsBaRY7_AujfoOeDybUPZNA5hTHiOI9KwwRRrAIsACq2wFpFjv8C6N-g54PJtQ9k0DmFMeI4j0rDBFGsAiwAKrbAWkWO_wLo36Dng8m1D2TQOYUx4jiPSsMEUawCLAAqtsBaRY7_AujfoOeDybUPZNA5hTHiOI9KwwRRrAIsACq2wFpFjv8C6N-g54PJtQ9k0DgEFAAAAAAAAAGFiY2RlAABhYoKkYWGLAAIDBAUGBwgKDQ9hYhBhY4UAAQIDBGFkBaRhYYcCAwQFBgcIYWIJYWOFAAECAwRhZAU"^^<https://w3id.org/security#multibase> _:c14n13 .
-    _:c14n12 <http://example.org/vocab/isPatientOf> _:c14n9 _:c14n5 .
-    _:c14n12 <http://schema.org/worksFor> _:c14n7 _:c14n5 .
-    _:c14n12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> _:c14n5 .
+    _:c14n1 <http://purl.org/dc/terms/created> "2023-02-09T09:35:07Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:c14n12 .
+    _:c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#DataIntegrityProof> _:c14n12 .
+    _:c14n1 <https://w3id.org/security#cryptosuite> "bbs-termwise-signature-2023" _:c14n12 .
+    _:c14n1 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> _:c14n12 .
+    _:c14n1 <https://w3id.org/security#verificationMethod> <did:example:issuer0#bls12_381-g2-pub001> _:c14n12 .
+    _:c14n10 <http://purl.org/dc/terms/created> "2024-08-23T02:45:49.981532998Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:c14n11 .
+    _:c14n10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#DataIntegrityProof> _:c14n11 .
+    _:c14n10 <https://w3id.org/security#challenge> "abcde" _:c14n11 .
+    _:c14n10 <https://w3id.org/security#cryptosuite> "bbs-termwise-proof-2023" _:c14n11 .
+    _:c14n10 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#authenticationMethod> _:c14n11 .
+    _:c14n10 <https://w3id.org/security#proofValue> "uomFhWQe4AgAAAAAAAAAAlWj7ySOnU5mw_rG271EltSGHfh0Sabj6_FBXzZ7GBT7TTXM-OJk2y-UjU8hAYyS9p5SkDSPYysuFjUy9RUNu4ypsNdZrRJX2E3TmTg-186q3jvPKExzchRPg7LrE6pWeqzMXck8jrsaUR1_zIsH6KKuTO5gnDEOV4Ufg8zCm7nDLetSoflGoX0d-AUrr9-C_j1WOnJ0-lOnlLr3Mg5hOjxDktjaDvUdwDJ36rFx7agxBvtUKa7deW1Ta-Vq1vFiiz2v7ALxtyrm5rzB1JBRdfsJet5Vb_FX3UQlG6TclU1KscOYL5gf92CsgvzkdItKJFaQmlbUaJ1G11h26l8lyRafN9HGrj29J4Uw6JxaWUcC-53KvYV7utm2rFr6hTN04SVl4k17LODqbiVuQ9BOYegABFwAAAAAAAAAAAAAAAAAAAEfN2HoEQky0MByRnjeWvLtZSGEhIAl4_eanyq9fTe9AAQAAAAAAAAAnJf1hjwcmRG9q37lvJE0D8YnXbv7DE94eFGr6hqNvGAIAAAAAAAAAX5Qjv-i24vQ4ksBHab08Nx2ubjuPAzhSvCaAOAlxRzUDAAAAAAAAAP7Yh-Mk-7oXrq5rka64MdYPtqgogXKNFwTw4YTBDDkkBAAAAAAAAAB6r3ptkYeMr6n3iF_bffXJl3oy7Vr17KHNZhihkJHVGQYAAAAAAAAA_JhzhRf5RjnOAJiYUB8ckVCm7t9JivkuHenkqeacSR0IAAAAAAAAAHuTD4mphlQyF3Y5tliZ3lYu9sKgPM_7U_itTfbIRnFvDgAAAAAAAAArpeH4MJzWqp1bzV53K-OYOYxcBwrFHeHMV6rJvEmxTw8AAAAAAAAARPVate_53JtTi530guf47C8pVN3pTohKmMVOE_nCzksQAAAAAAAAAJpdx4qaj1T1x8aLf8KCCE-ipO3ctzqtEI8WaxeIJzM3EgAAAAAAAAA3ZI0DRda1lDRTW9Bd_zkfZNg2hDBxqNIEXxaU7c4ARRMAAAAAAAAA6PcPvPkt4h4AoK17oQyjX6SzFGCocQY9yqbX8LTlmQsUAAAAAAAAAAE43979Qxp3ga1ZRpCKdM9fNmRBCsp9eQR9ydspesshFQAAAAAAAADOMZpaqHP6QOFdbVEuU_ZWDttdvOZSwlmFlk0XIyxEPBYAAAAAAAAAK05aN4CYMGQuKE116IZ0048SKqI_NOQ2Zqnh2Lwh7Q4XAAAAAAAAALX_BVDxoVLV2jwcesBstib4Qy4YFa7qyFsIrIJ-u3UZGQAAAAAAAAA0R3_Q5disVcF4K-AkQb_NKn2d18wpUuck2MVrLTH2DxoAAAAAAAAAFGrZ3fGrldBxfZalXu8eXfXb5OA-YEJfU7RdmYjsGAkbAAAAAAAAAAIQvfDpfxqY39XTkAJNYXvb7CKGZBY07bWE9B2qQG4sHAAAAAAAAACQ4-GIwNpLk7jQgug7LpoDrci6Sl54wZcbM-N-Ch0FXx4AAAAAAAAAt0WJscwZ7p22uxryXz3j6GdbARRmQJ0BH1RXuTlHNWUjAAAAAAAAAMW_o75vhhse34F_jGkABqr_AZGBX3YktM1LlK629V5lJAAAAAAAAACqe0mNBT7hWRZYmqrqzlhtPDDpEvWTCjeCLWhLzd8_EyUAAAAAAAAAAIxRE6_DuH0_ROAz-iV5j4yYsqr0xOfpjb00o--YJumt8jHt_iMy7xJE3zgJnR8i_q-_NGjQELZv9cVvbXyjXB4wc6vy1Oz9h-mclraqgHRaaALlnzqiX0VCoZRiLxZUKLHL4UyVFnqfCMmb_iAJI8Qp4VVuZTCSpHv0p0oO-4ySavNJfbSZhSnV8PpOCCFmTY9FKdqufrgWow1GWTBzYrQ_fQvaLJJc94kSoBR_xNR6QfC1UtPIPP9r05ubP2Vi7CWvzZctu5W5z9xYsP1inIchKJ-uhmXf2yxC2lVKxTlA1UfUUvnysTF8cWfwdoIR-8Mzjugdy8HwsqMVXDpZbxqiuAl3770_97VvG7-bLPJj35GhJmUwK8Tbw_xBFoMz9yWTIew6ivMP3F-9W2hCyzQAAQoAAAAAAAAAAAAAAAAAAAC7ZnA6NT9sxFpIobbBS0k0psK2jiaBJNx94yPcVxtKLwEAAAAAAAAAWraRE_rcXPgS8LeUoUxBkarEo9bqt_37Hb5Ri1IkDG0CAAAAAAAAAMxtH--szMw0uIlh-tM0zFLL7Q2_Vztj4qTOCAjWtFMvAwAAAAAAAACwgpD-v2spR63ppnFX8hBOFqIb39hC7iEqdJfkQ836BAQAAAAAAAAAcUkHxmQmHRWYaaGltyJxIVBhs7yTMUJARzhEo3ki5k0FAAAAAAAAAGkugnPRZhl3C_iCEHmZzIRAgkP6rbaUduaZRevg4wEgCAAAAAAAAABXL-gTFxBIsBE7O6ffqwXWm-vhSAZXXehyUn3bMLtoOw4AAAAAAAAAyK8UZpWesdRVp1YV4JWilwSRahgrir_-V4iNyIPHfE0TAAAAAAAAAJeY3RnElczE-wb4LYg9XOhSKI2xedR3m20-k92ZxPEzFAAAAAAAAADwsAEZU2x19ljCfYuPGt36dsYVRBMBGPFqVLwYT1FKYxUAAAAAAAAAAABhYoKkYWGLAAIDBAUGBwgKDQ9hYhBhY4UAAQIDBGFkBaRhYYcCAwQFBgcIYWIJYWOFAAECAwRhZAU"^^<https://w3id.org/security#multibase> _:c14n11 .
+    _:c14n13 <http://example.org/vocab/isPatientOf> _:c14n9 _:c14n5 .
+    _:c14n13 <http://schema.org/worksFor> _:c14n7 _:c14n5 .
+    _:c14n13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> _:c14n5 .
     _:c14n14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> _:c14n5 .
-    _:c14n14 <https://w3id.org/security#proof> _:c14n10 _:c14n5 .
-    _:c14n14 <https://www.w3.org/2018/credentials#credentialSubject> _:c14n12 _:c14n5 .
+    _:c14n14 <https://w3id.org/security#proof> _:c14n12 _:c14n5 .
+    _:c14n14 <https://www.w3.org/2018/credentials#credentialSubject> _:c14n13 _:c14n5 .
     _:c14n14 <https://www.w3.org/2018/credentials#expirationDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:c14n5 .
     _:c14n14 <https://www.w3.org/2018/credentials#issuanceDate> "2022-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:c14n5 .
     _:c14n14 <https://www.w3.org/2018/credentials#issuer> <did:example:issuer0> _:c14n5 .
@@ -1582,7 +1581,7 @@ mod tests {
     _:c14n2 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> _:c14n0 .
     _:c14n2 <https://w3id.org/security#verificationMethod> <did:example:issuer3#bls12_381-g2-pub001> _:c14n0 .
     _:c14n3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiablePresentation> .
-    _:c14n3 <https://w3id.org/security#proof> _:c14n13 .
+    _:c14n3 <https://w3id.org/security#proof> _:c14n11 .
     _:c14n3 <https://www.w3.org/2018/credentials#verifiableCredential> _:c14n5 .
     _:c14n3 <https://www.w3.org/2018/credentials#verifiableCredential> _:c14n6 .
     _:c14n4 <http://schema.org/status> "active" _:c14n6 .
@@ -3112,7 +3111,10 @@ _:b1 <http://schema.org/name> "ABC inc." .
         assert!(matches!(
             verified,
             Err(RDFProofsError::ProofSystem(
-                proof_system::prelude::ProofSystemError::LegoGroth16Error(_)
+                proof_system::prelude::ProofSystemError::LegoSnarkProofContributionFailed(
+                    1,
+                    legogroth16::error::Error::InvalidProof
+                )
             ))
         ));
     }
@@ -3251,7 +3253,10 @@ _:b1 <http://schema.org/name> "ABC inc." .
         assert!(matches!(
             verified,
             Err(RDFProofsError::ProofSystem(
-                proof_system::prelude::ProofSystemError::LegoGroth16Error(_)
+                proof_system::prelude::ProofSystemError::LegoSnarkProofContributionFailed(
+                    1,
+                    legogroth16::error::Error::InvalidProof
+                )
             ))
         ));
     }
@@ -3442,7 +3447,10 @@ _:b1 <http://schema.org/name> "ABC inc." .
         assert!(matches!(
             verified,
             Err(RDFProofsError::ProofSystem(
-                proof_system::prelude::ProofSystemError::LegoGroth16Error(_)
+                proof_system::prelude::ProofSystemError::LegoSnarkProofContributionFailed(
+                    1,
+                    legogroth16::error::Error::InvalidProof
+                )
             ))
         ));
     }
@@ -3630,7 +3638,10 @@ _:b1 <http://schema.org/name> "ABC inc." .
         assert!(matches!(
             verified,
             Err(RDFProofsError::ProofSystem(
-                proof_system::prelude::ProofSystemError::LegoGroth16Error(_)
+                proof_system::prelude::ProofSystemError::LegoSnarkProofContributionFailed(
+                    1,
+                    legogroth16::error::Error::InvalidProof
+                )
             ))
         ));
     }

--- a/src/derive_proof.rs
+++ b/src/derive_proof.rs
@@ -11,7 +11,6 @@ use crate::{
         BBSPlusSignature, Fr, PedersenCommitmentStmt, PoKBBSPlusStmt, PoKBBSPlusWit, Proof,
         ProofWithIndexMap, R1CSCircomWitness, StatementIndexMap, Statements,
     },
-    constants::PPID_PREFIX,
     context::{
         AUTHENTICATION, CHALLENGE, CIRCUIT, CREATED, CRYPTOSUITE, DATA_INTEGRITY_PROOF, DOMAIN,
         HOLDER, MULTIBASE, PREDICATE, PREDICATE_TYPE, PRIVATE, PROOF, PROOF_PURPOSE, PROOF_VALUE,
@@ -609,8 +608,7 @@ fn build_vp(
             ));
         }
         (Some(ppid), _) => {
-            let nym_multibase = ark_to_base64url(&ppid.ppid)?;
-            let vp_holder_id = NamedNode::new(format!("{}{}", PPID_PREFIX, nym_multibase))?;
+            let vp_holder_id = NamedNode::new(ppid.try_into_multibase()?)?;
             vp.insert(QuadRef::new(
                 &vp_id,
                 HOLDER,

--- a/src/derive_proof.rs
+++ b/src/derive_proof.rs
@@ -2958,18 +2958,27 @@ _:b1 <http://schema.org/name> "ABC inc." .
         // serialize
         let circuit_r1cs = ark_to_base64url(&circuit_r1cs).unwrap();
         let circuit_wasm = multibase::encode(Base::Base64Url, circuit_wasm);
-        let snark_proving_key = ark_to_base64url(&snark_proving_key).unwrap();
+        let snark_proving_key_string = ark_to_base64url(&snark_proving_key).unwrap();
+        let snark_verifying_key_string = ark_to_base64url(&snark_proving_key.vk).unwrap();
 
         // TODO: serde_json
-        let circuit_json = format!(
+        let circuit_json_for_prover = format!(
             r#"{{
   "id": "{circuit_id}",
   "r1cs": "{circuit_r1cs}",
   "wasm": "{circuit_wasm}",
-  "provingKey": "{snark_proving_key}"
+  "provingKey": "{snark_proving_key_string}"
 }}"#
         );
-        println!("{}", circuit_json);
+        println!("{}", circuit_json_for_prover);
+
+        let circuit_json_for_verifier = format!(
+            r#"{{
+  "id": "{circuit_id}",
+  "verifyingKey": "{snark_verifying_key_string}"
+}}"#
+        );
+        println!("{}", circuit_json_for_verifier);
     }
 
     #[test]
@@ -3017,7 +3026,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
         // serialize to multibase
         let circuit_r1cs = ark_to_base64url(&circuit_r1cs).unwrap();
         let circuit_wasm = multibase::encode(Base::Base64Url, circuit_wasm);
-        let snark_proving_key = ark_to_base64url(&snark_proving_key).unwrap();
+        let snark_proving_key_string = ark_to_base64url(&snark_proving_key).unwrap();
+        let snark_verifying_key_string = ark_to_base64url(&snark_proving_key.vk).unwrap();
 
         // generate SNARK proving key (by Verifier)
         let circuit = HashMap::from([(
@@ -3025,7 +3035,7 @@ _:b1 <http://schema.org/name> "ABC inc." .
             CircuitString {
                 circuit_r1cs: circuit_r1cs.clone(),
                 circuit_wasm: circuit_wasm.clone(),
-                snark_proving_key: snark_proving_key.clone(),
+                snark_proving_key: snark_proving_key_string.clone(),
             },
         )]);
 
@@ -3047,7 +3057,7 @@ _:b1 <http://schema.org/name> "ABC inc." .
 
         let snark_verifying_keys = HashMap::from([(
             "https://zkp-ld.org/circuit/lessThanPrvPub".to_string(),
-            snark_proving_key.clone(),
+            snark_verifying_key_string.clone(),
         )]);
 
         let verified = verify_proof_string(
@@ -3154,11 +3164,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
 
         // serialize to multibase
         let circuit_r1cs = ark_to_base64url(&circuit_r1cs).unwrap();
-        println!("\"r1cs\": \"{}\",", circuit_r1cs);
         let circuit_wasm = multibase::encode(Base::Base64Url, circuit_wasm);
-        println!("\"wasm\": \"{}\",", circuit_wasm);
-        let snark_proving_key = ark_to_base64url(&snark_proving_key).unwrap();
-        println!("\"snarkProvingKey\": \"{}\"", snark_proving_key);
+        let snark_proving_key_string = ark_to_base64url(&snark_proving_key).unwrap();
+        let snark_verifying_key_string = ark_to_base64url(&snark_proving_key.vk).unwrap();
 
         // generate SNARK proving key (by Verifier)
         let circuit = HashMap::from([(
@@ -3166,7 +3174,7 @@ _:b1 <http://schema.org/name> "ABC inc." .
             CircuitString {
                 circuit_r1cs: circuit_r1cs.clone(),
                 circuit_wasm: circuit_wasm.clone(),
-                snark_proving_key: snark_proving_key.clone(),
+                snark_proving_key: snark_proving_key_string.clone(),
             },
         )]);
 
@@ -3188,7 +3196,7 @@ _:b1 <http://schema.org/name> "ABC inc." .
 
         let snark_verifying_keys = HashMap::from([(
             "https://zkp-ld.org/circuit/lessThanEqPrvPub".to_string(),
-            snark_proving_key.clone(),
+            snark_verifying_key_string.clone(),
         )]);
 
         let verified = verify_proof_string(
@@ -3347,11 +3355,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
 
         // serialize to multibase
         let circuit_r1cs = ark_to_base64url(&circuit_r1cs).unwrap();
-        println!("\"r1cs\": \"{}\",", circuit_r1cs);
         let circuit_wasm = multibase::encode(Base::Base64Url, circuit_wasm);
-        println!("\"wasm\": \"{}\",", circuit_wasm);
-        let snark_proving_key = ark_to_base64url(&snark_proving_key).unwrap();
-        println!("\"snarkProvingKey\": \"{}\"", snark_proving_key);
+        let snark_proving_key_string = ark_to_base64url(&snark_proving_key).unwrap();
+        let snark_verifying_key_string = ark_to_base64url(&snark_proving_key.vk).unwrap();
 
         // generate SNARK proving key (by Verifier)
         let circuit = HashMap::from([(
@@ -3359,7 +3365,7 @@ _:b1 <http://schema.org/name> "ABC inc." .
             CircuitString {
                 circuit_r1cs: circuit_r1cs.clone(),
                 circuit_wasm: circuit_wasm.clone(),
-                snark_proving_key: snark_proving_key.clone(),
+                snark_proving_key: snark_proving_key_string.clone(),
             },
         )]);
 
@@ -3381,7 +3387,7 @@ _:b1 <http://schema.org/name> "ABC inc." .
 
         let snark_verifying_keys = HashMap::from([(
             "https://zkp-ld.org/circuit/lessThanPrvPub".to_string(),
-            snark_proving_key.clone(),
+            snark_verifying_key_string.clone(),
         )]);
 
         let verified = verify_proof_string(
@@ -3536,11 +3542,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
 
         // serialize to multibase
         let circuit_r1cs = ark_to_base64url(&circuit_r1cs).unwrap();
-        println!("\"r1cs\": \"{}\",", circuit_r1cs);
         let circuit_wasm = multibase::encode(Base::Base64Url, circuit_wasm);
-        println!("\"wasm\": \"{}\",", circuit_wasm);
-        let snark_proving_key = ark_to_base64url(&snark_proving_key).unwrap();
-        println!("\"snarkProvingKey\": \"{}\"", snark_proving_key);
+        let snark_proving_key_string = ark_to_base64url(&snark_proving_key).unwrap();
+        let snark_verifying_key_string = ark_to_base64url(&snark_proving_key.vk).unwrap();
 
         // generate SNARK proving key (by Verifier)
         let circuit = HashMap::from([(
@@ -3548,7 +3552,7 @@ _:b1 <http://schema.org/name> "ABC inc." .
             CircuitString {
                 circuit_r1cs: circuit_r1cs.clone(),
                 circuit_wasm: circuit_wasm.clone(),
-                snark_proving_key: snark_proving_key.clone(),
+                snark_proving_key: snark_proving_key_string.clone(),
             },
         )]);
 
@@ -3570,7 +3574,7 @@ _:b1 <http://schema.org/name> "ABC inc." .
 
         let snark_verifying_keys = HashMap::from([(
             "https://zkp-ld.org/circuit/lessThanPrvPub".to_string(),
-            snark_proving_key.clone(),
+            snark_verifying_key_string.clone(),
         )]);
 
         let verified = verify_proof_string(

--- a/src/derive_proof.rs
+++ b/src/derive_proof.rs
@@ -19,7 +19,7 @@ use crate::{
         VERIFIABLE_PRESENTATION_TYPE, VERIFICATION_METHOD,
     },
     error::RDFProofsError,
-    key_gen::{generate_params, generate_ppid, PPID},
+    key_gen::{generate_params, PPID},
     key_graph::KeyGraph,
     ordered_triple::{
         OrderedGraphViews, OrderedNamedOrBlankNode, OrderedVerifiableCredentialGraphViews,
@@ -380,7 +380,7 @@ fn get_ppid(
     }
 
     if let (Some(domain), Some(secret)) = (domain, secret) {
-        Ok(Some(generate_ppid(domain, secret)?))
+        Ok(Some(PPID::new(secret, domain)?))
     } else {
         Err(RDFProofsError::MissingSecretOrDomain)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ pub enum RDFProofsError {
     InvalidVerificationMethod,
     MalformedProof,
     Multibase(multibase::Error),
+    InvalidMulticodec,
+    UnsupportedMulticodec(u64),
     MissingInputToDeriveProof,
     IriParse(oxiri::IriParseError),
     TtlParse(oxttl::TurtleParseError),
@@ -83,6 +85,10 @@ impl std::fmt::Display for RDFProofsError {
             }
             RDFProofsError::MalformedProof => write!(f, "malformed proof error"),
             RDFProofsError::Multibase(_) => write!(f, "multibase error"),
+            RDFProofsError::InvalidMulticodec => write!(f, "invalid multicodec error"),
+            RDFProofsError::UnsupportedMulticodec(codec) => {
+                write!(f, "unsupported multicodec error: {}", codec)
+            }
             RDFProofsError::MissingInputToDeriveProof => {
                 write!(
                     f,

--- a/src/key_gen.rs
+++ b/src/key_gen.rs
@@ -1,4 +1,5 @@
 use crate::{
+    ark_to_base64url,
     common::{get_hasher, hash_byte_to_field, BBSPlusHash, BBSPlusKeypair, BBSPlusParams},
     constants::{GENERATOR_SEED, PPID_PREFIX, PPID_SEED},
     error::RDFProofsError,
@@ -61,6 +62,11 @@ impl PPID {
             domain: domain.to_string(),
             base: base.into(),
         })
+    }
+
+    pub fn try_into_multibase(&self) -> Result<String, RDFProofsError> {
+        let ppid_multibase = ark_to_base64url(&self.ppid)?;
+        Ok(format!("{}{}", PPID_PREFIX, ppid_multibase))
     }
 
     fn generate_base(domain: &str) -> Result<G1Affine, RDFProofsError> {

--- a/src/key_gen.rs
+++ b/src/key_gen.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{
-        ark_to_base64url_with_codec, get_hasher, hash_byte_to_field, multibase_with_codec_to_ark,
-        BBSPlusHash, BBSPlusKeypair, BBSPlusParams, Multicodec,
+        ark_to_base58btc_with_codec, ark_to_base64url_with_codec, get_hasher, hash_byte_to_field,
+        multibase_with_codec_to_ark, BBSPlusHash, BBSPlusKeypair, BBSPlusParams, Multicodec,
     },
     constants::{GENERATOR_SEED, PPID_PREFIX, PPID_SEED},
     error::RDFProofsError,

--- a/src/key_gen.rs
+++ b/src/key_gen.rs
@@ -1,9 +1,9 @@
 use crate::{
     common::{
-        ark_to_base58btc_with_codec, ark_to_base64url_with_codec, get_hasher, hash_byte_to_field,
-        multibase_with_codec_to_ark, BBSPlusHash, BBSPlusKeypair, BBSPlusParams, Multicodec,
+        ark_to_base58btc, get_hasher, hash_byte_to_field, multibase_with_codec_to_ark,
+        BBSPlusHash, BBSPlusKeypair, BBSPlusParams, Multicodec,
     },
-    constants::{GENERATOR_SEED, PPID_PREFIX, PPID_SEED},
+    constants::{DID_KEY_PREFIX, GENERATOR_SEED, PPID_SEED},
     error::RDFProofsError,
 };
 use ark_bls12_381::G1Affine;
@@ -51,9 +51,9 @@ impl PPID {
         })
     }
 
-    pub fn try_from_multibase(multibase: &str, domain: &str) -> Result<Self, RDFProofsError> {
-        let ppid_multibase = multibase
-            .strip_prefix(PPID_PREFIX)
+    pub fn try_from_did_key(did_key: &str, domain: &str) -> Result<Self, RDFProofsError> {
+        let ppid_multibase = did_key
+            .strip_prefix(DID_KEY_PREFIX)
             .ok_or(RDFProofsError::InvalidPPID)?;
         let (_, ppid) = multibase_with_codec_to_ark(ppid_multibase)?;
         let base = Self::generate_base(domain)?;
@@ -65,9 +65,9 @@ impl PPID {
         })
     }
 
-    pub fn try_into_multibase(&self) -> Result<String, RDFProofsError> {
-        let ppid_base64url = ark_to_base64url_with_codec(&self.ppid, Multicodec::Bls12381G1Pub)?;
-        Ok(format!("{}{}", PPID_PREFIX, ppid_base64url))
+    pub fn try_into_did_key(&self) -> Result<String, RDFProofsError> {
+        let ppid_base58btc = ark_to_base58btc(&self.ppid, Multicodec::Bls12381G1Pub)?;
+        Ok(format!("{}{}", DID_KEY_PREFIX, ppid_base58btc))
     }
 
     fn generate_base(domain: &str) -> Result<G1Affine, RDFProofsError> {
@@ -82,7 +82,7 @@ impl PPID {
 mod tests {
     use super::generate_keypair;
     use crate::{
-        common::{ark_to_base58btc_with_codec, ark_to_base64url, Multicodec},
+        common::{ark_to_base58btc, ark_to_base64url, Multicodec},
         key_gen::generate_params,
     };
     use ark_std::rand::{rngs::StdRng, SeedableRng};
@@ -116,9 +116,9 @@ mod tests {
 
         let keypair = generate_keypair(&mut rng).unwrap();
         let secret_key =
-            ark_to_base58btc_with_codec(&keypair.secret_key, Multicodec::Bls12381G2Priv).unwrap();
+            ark_to_base58btc(&keypair.secret_key, Multicodec::Bls12381G2Priv).unwrap();
         let public_key =
-            ark_to_base58btc_with_codec(&keypair.public_key, Multicodec::Bls12381G2Pub).unwrap();
+            ark_to_base58btc(&keypair.public_key, Multicodec::Bls12381G2Pub).unwrap();
         println!("secret_key: {}", secret_key);
         println!("public_key: {}", public_key);
 

--- a/src/key_graph.rs
+++ b/src/key_graph.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::{multibase_to_ark, BBSPlusPublicKey, BBSPlusSecretKey},
+    common::{multibase_with_codec_to_ark, BBSPlusPublicKey, BBSPlusSecretKey},
     context::{PUBLIC_KEY_MULTIBASE, SECRET_KEY_MULTIBASE},
     error::RDFProofsError,
 };
@@ -49,7 +49,9 @@ impl KeyGraph {
             TermRef::Literal(v) => v.value(),
             _ => return Err(RDFProofsError::InvalidVerificationMethod),
         };
-        let secret_key = multibase_to_ark(secret_key_multibase)?;
+        let (_codec, secret_key) = multibase_with_codec_to_ark(secret_key_multibase)?;
+        // TODO: check codec
+
         Ok(secret_key)
     }
 
@@ -67,7 +69,9 @@ impl KeyGraph {
             TermRef::Literal(v) => v.value(),
             _ => return Err(RDFProofsError::InvalidVerificationMethod),
         };
-        let public_key = multibase_to_ark(public_key_multibase)?;
+        let (_codec, public_key) = multibase_with_codec_to_ark(public_key_multibase)?;
+        // TODO: check codec
+
         Ok(public_key)
     }
 

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -13,9 +13,9 @@ pub struct Circuit {
 
 impl Circuit {
     pub fn new(r1cs: &str, wasm: &str, proving_key: &str) -> Result<Self, RDFProofsError> {
-        let r1cs: R1CS = multibase_to_ark(r1cs)?;
+        let r1cs = multibase_to_ark(r1cs)?;
         let (_, wasm) = multibase::decode(wasm)?;
-        let proving_key: ProvingKey = multibase_to_ark(proving_key)?;
+        let proving_key = multibase_to_ark(proving_key)?;
         Ok(Self {
             r1cs,
             wasm,

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -1,7 +1,6 @@
 use crate::{
-    common::{ProvingKey, R1CS},
+    common::{multibase_to_ark, ProvingKey, R1CS},
     error::RDFProofsError,
-    multibase_to_ark,
 };
 use serde::{Deserialize, Serialize};
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -292,6 +292,28 @@ mod tests {
     _:b0 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> .
     _:b0 <https://w3id.org/security#verificationMethod> <did:example:issuer3#bls12_381-g2-pub001> .
     "#;
+    const _VC_4: &str = r#"
+    <did:example:john> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .
+    <did:example:john> <http://schema.org/name> "John Smith" .
+    <did:example:john> <http://example.org/vocab/isPatientOf> _:b0 .
+    _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/vocab/Vaccination> .
+    _:b0 <http://example.org/vocab/vaccinationDate> "2022-01-01T00:00:00Z"^^<http://schema.org/DateTime> . # use schema.org instead of xsd
+    <http://example.org/vcred/00> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+    <http://example.org/vcred/00> <https://www.w3.org/2018/credentials#credentialSubject> <did:example:john> .
+    <http://example.org/vcred/00> <https://www.w3.org/2018/credentials#issuer> <did:example:issuer0> .
+    <http://example.org/vcred/00> <https://www.w3.org/2018/credentials#issuanceDate> "2022-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+    <http://example.org/vcred/00> <https://www.w3.org/2018/credentials#expirationDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+    "#;
+    const _VC_5: &str = r#"
+    <urn:example:prod1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Product> .
+    <urn:example:prod1> <http://schema.org/name> "Awesome Product" .
+    <urn:example:prod1> <http://schema.org/price> "300"^^<http://www.w3.org/2001/XMLSchema#integer> .
+    <http://example.org/vcred/00> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
+    <http://example.org/vcred/00> <https://www.w3.org/2018/credentials#credentialSubject> <urn:example:prod1> .
+    <http://example.org/vcred/00> <https://www.w3.org/2018/credentials#issuer> <did:example:issuer0> .
+    <http://example.org/vcred/00> <https://www.w3.org/2018/credentials#issuanceDate> "2022-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+    <http://example.org/vcred/00> <https://www.w3.org/2018/credentials#expirationDate> "2025-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+    "#;
 
     fn print_signature(vc: &VerifiableCredential) {
         let proof_value_triple = vc.proof.triples_for_predicate(PROOF_VALUE).next().unwrap();

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -176,26 +176,26 @@ mod tests {
     <did:example:issuer0> <https://w3id.org/security#verificationMethod> <did:example:issuer0#bls12_381-g2-pub001> .
     <did:example:issuer0#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
     <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer0> .
-    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "uekl-7abY7R84yTJEJ6JRqYohXxPZPDoTinJ7XCcBkmk" .
-    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "ukiiQxfsSfV0E2QyBlnHTK2MThnd7_-Fyf6u76BUd24uxoDF4UjnXtxUo8b82iuPZBOa8BXd1NpE20x3Rfde9udcd8P8nPVLr80Xh6WLgI9SYR6piNzbHhEVIfgd_Vo9P" .
+    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z4893E1L7AeYfqaduUdLYgcxefWAah8gJB8RhPi7JHQkdRbe" .
+    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC77BjGcGDVWfBdgzqwzp3uuWkoWuRMe8pnx4dkncia5t9LKHVt96BPGBizeSU7BKiV35h1tsuVwHUVt4arZuckxGCb2tTsB3fsY66mQNs5Bwoac2w2iyYFe8uenBUYdAiveEr" .
     # issuer1
     <did:example:issuer1> <https://w3id.org/security#verificationMethod> <did:example:issuer1#bls12_381-g2-pub001> .
     <did:example:issuer1#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
     <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer1> .
-    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "uQkpZn0SW42c2tlYa0IIFXyabAYHbwc0z3l_GvXQbWSg" .
-    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "usFM3CcvBMl_Dg5ixhQkHKGdqzY3GU9Uck6lj2i8vpbzLFOiZnjDNOpsItrkbNf2iCku-SZu5kO3nbLis-fuRhz_QwFcKw9IBpbPRPwXNQTX3zzcFsoNzs_wo8tkLQlcS" .
+    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z488yTRFj1e7W6s6MVN6iYm6taiNByQwSCg2XwgEJvAcXr15" .
+    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC7HaSjNELSGG8QnYdMvNurgfWfdGNo1Znqds6CoYQ24qKKWogiLtKWPoCLJapEYdKAMN9r6bdF9MeNrfV3fhUzkKwrfUewD5yVhwSVpM4tjv87YVgWGRTUuesxf7scabbPAnD" .
     # issuer2
     <did:example:issuer2> <https://w3id.org/security#verificationMethod> <did:example:issuer2#bls12_381-g2-pub001> .
     <did:example:issuer2#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
     <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer2> .
-    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "u4nmBsiSwvHj7i_gBu1L6Cug0OXXhVPF6NWLfkQbCZiU" .
-    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "uo_yMZWlZwQzLqEe6hEsORbsV5cSHQEQHNI0EOe_eUJdHsgCRxtpWMcxxcdshH5pAAUxt_ni6_cQCud3CdMcjAUN8yOvzhuzeIW_H-Dyncdrc3w0f2WxdH3oRcnvPTwrb" .
+    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z489AEiC5VbeLmVZxokiJYkXNZrMza9eCiPZ51ekgcV9mNvG" .
+    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC7DKvfSfydgg48FpP53HgsLfWrVHfrmUXbwvw8AnSgW1JiA5741mwe3hpMNNRMYh3BgR9ebxvGAxPxFhr8F3jQHZANqb3if2MycjQN3ZBSWP3aGoRyat294icdVMDhTqoKXeJ" .
     # issuer3
     <did:example:issuer3> <https://w3id.org/security#verificationMethod> <did:example:issuer3#bls12_381-g2-pub001> .
     <did:example:issuer3#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
     <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer3> .
-    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "uH1yGFG6C1pJd_N45wkOPrSNdvILdLm0c_0AXXRDGZy8" .
-    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "uidSE_Urr5MFE4SoqV3TZTBHPHM-tkpdRhBPrYeIbsudglVV_cddyEstHJOmSkfPOFsvEuA9qtWjFNpBebVSS4DPxBfNNWESSCz_vrnH62hbfpWdJSFR8YbqjborvpgM6" .
+    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z488w754KqucDkNxCWCoi5DkH6pvEt6aNZNYYYoKmDDx8m5G" .
+    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC74KLKQtdApVyY3EbAZfiW6A7HdwSZVLsBF2vs5512YwNWs5PRYiqavzWLoiAq6UcKLv6RAnUM9Y117Pg4LayaBMa9euz23C2TDtBq8QuhpbDRDqsjUxLS5S9ruWRk71SEo69" .
     "#;
 
     const VC_1: &str = r#"

--- a/src/verify_proof.rs
+++ b/src/verify_proof.rs
@@ -1,9 +1,10 @@
 use crate::{
     common::{
         generate_proof_spec_context, get_dataset_from_nquads, get_delimiter,
-        get_graph_from_ntriples, get_hasher, hash_term_to_field, is_nym, read_private_var_list,
-        read_public_var_list, reorder_vc_triples, BBSPlusHash, BBSPlusPublicKey, Fr,
-        PedersenCommitmentStmt, PoKBBSPlusStmt, ProofWithIndexMap, Statements, VerifyingKey,
+        get_graph_from_ntriples, get_hasher, hash_term_to_field, is_nym, multibase_to_ark,
+        read_private_var_list, read_public_var_list, reorder_vc_triples, BBSPlusHash,
+        BBSPlusPublicKey, Fr, PedersenCommitmentStmt, PoKBBSPlusStmt, ProofWithIndexMap,
+        Statements, VerifyingKey,
     },
     context::{
         CHALLENGE, CIRCUIT, DOMAIN, HOLDER, PREDICATE_TYPE, PRIVATE, PROOF_VALUE, PUBLIC,
@@ -12,7 +13,6 @@ use crate::{
     error::RDFProofsError,
     key_gen::{generate_params, PPID},
     key_graph::KeyGraph,
-    multibase_to_ark,
     ordered_triple::OrderedNamedOrBlankNode,
     vc::{DisclosedVerifiableCredential, VerifiableCredentialTriples, VerifiablePresentation},
 };

--- a/src/verify_proof.rs
+++ b/src/verify_proof.rs
@@ -3,7 +3,7 @@ use crate::{
         generate_proof_spec_context, get_dataset_from_nquads, get_delimiter,
         get_graph_from_ntriples, get_hasher, hash_term_to_field, is_nym, multibase_to_ark,
         read_private_var_list, read_public_var_list, reorder_vc_triples, BBSPlusHash,
-        BBSPlusPublicKey, Fr, PedersenCommitmentStmt, PoKBBSPlusStmt, ProofWithIndexMap,
+        BBSPlusPublicKey, Fr, PedersenCommitmentStmt, PoKBBSPlusStmtVerifier, ProofWithIndexMap,
         Statements, VerifyingKey,
     },
     context::{
@@ -191,7 +191,7 @@ pub fn verify_proof<R: RngCore>(
     for (DisclosedTerms { disclosed, .. }, (params, public_key)) in
         disclosed_terms.iter().zip(params_and_pks)
     {
-        statements.add(PoKBBSPlusStmt::new_statement_from_params(
+        statements.add(PoKBBSPlusStmtVerifier::new_statement_from_params(
             params,
             public_key,
             disclosed.clone(),

--- a/src/verify_proof.rs
+++ b/src/verify_proof.rs
@@ -363,7 +363,7 @@ fn get_ppid(metadata: &GraphView, domain: &str) -> Result<Option<PPID>, RDFProof
         Some(TermRef::NamedNode(n)) => n.as_str(),
         _ => return Ok(None),
     };
-    let ppid = PPID::try_from_multibase(holder_subject, domain)?;
+    let ppid = PPID::try_from_did_key(holder_subject, domain)?;
     Ok(Some(ppid))
 }
 


### PR DESCRIPTION
### Changed

- **BREAKING** Changed key encoding format from `base64url` to `base58btc` + `multicodecs`
- **BREAKING** Replaced PPID representation with `did:key` instead of `ppid:`
- **BREAKING** Upgraded `docknetwork/crypto` libraries (`proof_system`, `bbs_plus`, `dock_crypto_utils`, `legogroth16`) resulting in breaking changes in several cryptographic objects
- Updated `oxrdf`, `oxttl`, `rdf-canon`, and other dependencies

### Fixed

- Separated zk-SNARK proving keys and verifying keys in several test cases
