### PR TITLE
v0.10.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.10.0-alpha.1] - 2024-08-24
+
+### Changed
+
+- Added `KeyPairBase58Btc` to generate base58btc-encoded keypairs
+- Upgraded `oxsdatatypes` and `oxiri` dependencies
+
 ## [0.10.0-alpha.0] - 2024-08-23
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdf-proofs"
-version = "0.10.0-alpha.0"
+version = "0.10.0-alpha.1"
 edition = "2021"
 authors = ["yamdan"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ serde_with = "3.9"
 
 oxrdf = "0.2.0-alpha.6"
 oxttl = "0.1.0-alpha.7"
-oxsdatatypes = "0.2.0-alpha.1"
-oxiri = "0.2.3-alpha.1"
+oxsdatatypes = "0.2.0-alpha.2"
+oxiri = "0.2.4"
 
 rdf-canon = "0.15.0-alpha.6"
 

--- a/src/derive_proof.rs
+++ b/src/derive_proof.rs
@@ -1392,8 +1392,8 @@ fn build_disclosed_and_undisclosed_terms(
 mod tests {
     use super::CircuitString;
     use crate::{
-        ark_to_base64url, blind_sign_string, blind_verify_string,
-        common::{get_dataset_from_nquads, get_graph_from_ntriples, R1CS},
+        blind_sign_string, blind_verify_string,
+        common::{ark_to_base64url, get_dataset_from_nquads, get_graph_from_ntriples, R1CS},
         derive_proof,
         derive_proof::get_deanon_map_from_string,
         derive_proof_string,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub use blind_signature::{
 };
 pub use common::{ark_to_base64url, ark_to_multibase, multibase_to_ark};
 pub use derive_proof::{derive_proof, derive_proof_string};
+pub use key_gen::KeyPairBase58Btc;
 pub use key_graph::KeyGraph;
 pub use predicate::CircuitString;
 pub use signature::{sign, sign_string, verify, verify_string};


### PR DESCRIPTION
### Changed

- Added `KeyPairBase58Btc` to generate base58btc-encoded keypairs
- Upgraded `oxsdatatypes` and `oxiri` dependencies
