### PR TITLE
v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.10.0] - 2024-09-25
+
+### Added
+
+- Added more detailed errors related to verification methods
+
+### Changed
+
+- Upgraded `oxrdf`, `oxttl`, `oxsdatatypes`, and `rdf-canon` dependencies, allowing us to remove the `alpha` tag from the version
+- Upgraded `serde_cbor` to `ciborium` for CBOR serialization to resolve [RUSTSEC-2021-0127](https://rustsec.org/advisories/RUSTSEC-2021-0127)
+- Refactored `KeyGraph` struct
+
 ## [0.10.0-alpha.1] - 2024-08-24
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,12 @@ serde = "1.0"
 serde_cbor = "0.11"
 serde_with = "3.9"
 
-oxrdf = "0.2.0-alpha.6"
-oxttl = "0.1.0-alpha.7"
-oxsdatatypes = "0.2.0-alpha.2"
+oxrdf = "0.2.0"
+oxttl = "0.1.0"
+oxsdatatypes = "0.2.0"
 oxiri = "0.2.4"
 
-rdf-canon = "0.15.0-alpha.6"
+rdf-canon = "0.15.0"
 
 proof_system = { version = "0.31", default-features = false }
 bbs_plus = { version = "0.22", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ multibase = "0.9"
 unsigned-varint = "0.8"
 
 serde = "1.0"
-serde_cbor = "0.11"
+ciborium = "0.2"
 serde_with = "3.9"
 
 oxrdf = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdf-proofs"
-version = "0.10.0-alpha.1"
+version = "0.10.0"
 edition = "2021"
 authors = ["yamdan"]
 license = "MIT"

--- a/src/common.rs
+++ b/src/common.rs
@@ -482,14 +482,14 @@ pub fn reorder_vc_triples(
 
 pub fn get_graph_from_ntriples(ntriples: &str) -> Result<Graph, RDFProofsError> {
     let iter = NTriplesParser::new()
-        .parse_read(ntriples.as_bytes())
+        .for_reader(ntriples.as_bytes())
         .collect::<Result<Vec<_>, _>>()?;
     Ok(Graph::from_iter(iter))
 }
 
 pub fn get_dataset_from_nquads(nquads: &str) -> Result<Dataset, RDFProofsError> {
     let iter = NQuadsParser::new()
-        .parse_read(nquads.as_bytes())
+        .for_reader(nquads.as_bytes())
         .collect::<Result<Vec<_>, _>>()?;
     Ok(Dataset::from_iter(iter))
 }

--- a/src/derive_proof.rs
+++ b/src/derive_proof.rs
@@ -14,7 +14,7 @@ use crate::{
         AUTHENTICATION, CHALLENGE, CIRCUIT, CREATED, CRYPTOSUITE, DATA_INTEGRITY_PROOF, DOMAIN,
         HOLDER, MULTIBASE, PREDICATE, PREDICATE_TYPE, PRIVATE, PROOF, PROOF_PURPOSE, PROOF_VALUE,
         PUBLIC, SECRET_COMMITMENT, VERIFIABLE_CREDENTIAL, VERIFIABLE_CREDENTIAL_TYPE,
-        VERIFIABLE_PRESENTATION_TYPE, VERIFICATION_METHOD,
+        VERIFIABLE_PRESENTATION_TYPE,
     },
     error::RDFProofsError,
     key_gen::{generate_params, PPID},
@@ -82,7 +82,7 @@ pub fn derive_proof<R: RngCore>(
     // get issuer public keys
     let public_keys = vc_pairs
         .iter()
-        .map(|VcPair { original: vc, .. }| get_public_keys(&vc.proof, key_graph))
+        .map(|VcPair { original: vc, .. }| key_graph.get_public_key_from_proof_graph(&vc.proof))
         .collect::<Result<Vec<_>, _>>()?;
     println!("public keys:\n{:#?}\n", public_keys);
 
@@ -399,21 +399,6 @@ fn get_deanon_map_from_string(
             Ok((key, value))
         })
         .collect()
-}
-
-fn get_public_keys(
-    proof_graph: &Graph,
-    key_graph: &KeyGraph,
-) -> Result<BBSPlusPublicKey, RDFProofsError> {
-    let vm_triple = proof_graph
-        .triples_for_predicate(VERIFICATION_METHOD)
-        .next()
-        .ok_or(RDFProofsError::InvalidVerificationMethod)?;
-    let vm = match vm_triple.object {
-        TermRef::NamedNode(v) => Ok(v),
-        _ => Err(RDFProofsError::InvalidVerificationMethodURL),
-    }?;
-    key_graph.get_public_key(vm)
 }
 
 fn deanonymize_subject(

--- a/src/derive_proof.rs
+++ b/src/derive_proof.rs
@@ -1201,7 +1201,8 @@ fn serialize_proof_with_index_map(
         proof,
         index_map: index_map.clone(),
     };
-    let proof_with_index_map_cbor = serde_cbor::to_vec(&proof_with_index_map)?;
+    let mut proof_with_index_map_cbor = Vec::new();
+    ciborium::ser::into_writer(&proof_with_index_map, &mut proof_with_index_map_cbor)?;
     let proof_with_index_map_multibase =
         multibase::encode(Base::Base64Url, proof_with_index_map_cbor);
     Ok(proof_with_index_map_multibase)

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,8 @@ pub enum RDFProofsError {
     BBSPlus(bbs_plus::prelude::BBSPlusError),
     HashToField,
     ArkSerialization(ark_serialize::SerializationError),
-    CBORSerialization(serde_cbor::Error),
+    CBORSerialization(ciborium::ser::Error<std::io::Error>),
+    CBORDeserialization(ciborium::de::Error<std::io::Error>),
     ProofTransformation,
     InvalidProofConfiguration,
     InvalidProofDatetime,
@@ -74,6 +75,7 @@ impl std::fmt::Display for RDFProofsError {
             RDFProofsError::HashToField => write!(f, "hash to field is failed"),
             RDFProofsError::ArkSerialization(_) => write!(f, "arkworks serialization error"),
             RDFProofsError::CBORSerialization(_) => write!(f, "CBOR serialization error"),
+            RDFProofsError::CBORDeserialization(_) => write!(f, "CBOR deserialization error"),
             RDFProofsError::ProofTransformation => write!(f, "proof transformation error"),
             RDFProofsError::InvalidProofConfiguration => {
                 write!(f, "invalid proof configuration error")
@@ -233,9 +235,15 @@ impl From<ark_serialize::SerializationError> for RDFProofsError {
     }
 }
 
-impl From<serde_cbor::Error> for RDFProofsError {
-    fn from(e: serde_cbor::Error) -> Self {
+impl From<ciborium::ser::Error<std::io::Error>> for RDFProofsError {
+    fn from(e: ciborium::ser::Error<std::io::Error>) -> Self {
         Self::CBORSerialization(e)
+    }
+}
+
+impl From<ciborium::de::Error<std::io::Error>> for RDFProofsError {
+    fn from(e: ciborium::de::Error<std::io::Error>) -> Self {
+        Self::CBORDeserialization(e)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,10 @@ pub enum RDFProofsError {
     InvalidProofDatetime,
     ProofGeneration,
     InvalidVerificationMethodURL,
-    InvalidVerificationMethod,
+    InvalidVerificationMethodKey,
+    InvalidVerificationMethodKeyCodec,
+    VerificationMethodNotFound,
+    VerificationMethodNotFoundInProof,
     MalformedProof,
     Multibase(multibase::Error),
     InvalidMulticodec,
@@ -80,8 +83,17 @@ impl std::fmt::Display for RDFProofsError {
             RDFProofsError::InvalidVerificationMethodURL => {
                 write!(f, "invalid verification method URL error")
             }
-            RDFProofsError::InvalidVerificationMethod => {
-                write!(f, "invalid verification method error")
+            RDFProofsError::InvalidVerificationMethodKey => {
+                write!(f, "invalid verification method key error")
+            }
+            RDFProofsError::InvalidVerificationMethodKeyCodec => {
+                write!(f, "invalid verification method key codec error")
+            }
+            RDFProofsError::VerificationMethodNotFound => {
+                write!(f, "verification method not found error")
+            }
+            RDFProofsError::VerificationMethodNotFoundInProof => {
+                write!(f, "verification method not found in proof error")
             }
             RDFProofsError::MalformedProof => write!(f, "malformed proof error"),
             RDFProofsError::Multibase(_) => write!(f, "multibase error"),

--- a/src/key_graph.rs
+++ b/src/key_graph.rs
@@ -1,9 +1,9 @@
 use crate::{
     common::{multibase_with_codec_to_ark, BBSPlusPublicKey, BBSPlusSecretKey},
-    context::{PUBLIC_KEY_MULTIBASE, SECRET_KEY_MULTIBASE},
+    context::{PUBLIC_KEY_MULTIBASE, SECRET_KEY_MULTIBASE, VERIFICATION_METHOD},
     error::RDFProofsError,
 };
-use oxrdf::{Graph, NamedNodeRef, TermRef, Triple};
+use oxrdf::{dataset::GraphView, Graph, NamedNodeRef, TermRef, Triple, TripleRef};
 
 pub struct KeyGraph {
     inner: Graph,
@@ -28,28 +28,28 @@ impl KeyGraph {
     pub fn retrieve_verification_method(
         &self,
         verification_method_identifier: NamedNodeRef,
-    ) -> Result<Graph, RDFProofsError> {
-        Ok(Graph::from_iter(
+    ) -> Graph {
+        Graph::from_iter(
             self.inner
                 .triples_for_subject(verification_method_identifier),
-        ))
+        )
     }
 
     pub fn get_secret_key(
         &self,
         verification_method_identifier: NamedNodeRef,
     ) -> Result<BBSPlusSecretKey, RDFProofsError> {
-        let verification_method =
-            self.retrieve_verification_method(verification_method_identifier)?;
+        let verification_method = self.retrieve_verification_method(verification_method_identifier);
 
         let secret_key_term = verification_method
             .object_for_subject_predicate(verification_method_identifier, SECRET_KEY_MULTIBASE)
-            .ok_or(RDFProofsError::InvalidVerificationMethod)?;
+            .ok_or(RDFProofsError::VerificationMethodNotFound)?;
         let secret_key_multibase = match secret_key_term {
             TermRef::Literal(v) => v.value(),
-            _ => return Err(RDFProofsError::InvalidVerificationMethod),
+            _ => return Err(RDFProofsError::InvalidVerificationMethodKey),
         };
-        let (_codec, secret_key) = multibase_with_codec_to_ark(secret_key_multibase)?;
+        let (_codec, secret_key) = multibase_with_codec_to_ark(secret_key_multibase)
+            .map_err(|_| RDFProofsError::InvalidVerificationMethodKeyCodec)?;
         // TODO: check codec
 
         Ok(secret_key)
@@ -59,20 +59,53 @@ impl KeyGraph {
         &self,
         verification_method_identifier: NamedNodeRef,
     ) -> Result<BBSPlusPublicKey, RDFProofsError> {
-        let verification_method =
-            self.retrieve_verification_method(verification_method_identifier)?;
+        let verification_method = self.retrieve_verification_method(verification_method_identifier);
 
         let public_key_term = verification_method
             .object_for_subject_predicate(verification_method_identifier, PUBLIC_KEY_MULTIBASE)
-            .ok_or(RDFProofsError::InvalidVerificationMethod)?;
+            .ok_or(RDFProofsError::VerificationMethodNotFound)?;
         let public_key_multibase = match public_key_term {
             TermRef::Literal(v) => v.value(),
-            _ => return Err(RDFProofsError::InvalidVerificationMethod),
+            _ => return Err(RDFProofsError::InvalidVerificationMethodKey),
         };
-        let (_codec, public_key) = multibase_with_codec_to_ark(public_key_multibase)?;
+        let (_codec, public_key) = multibase_with_codec_to_ark(public_key_multibase)
+            .map_err(|_| RDFProofsError::InvalidVerificationMethodKeyCodec)?;
         // TODO: check codec
 
         Ok(public_key)
+    }
+
+    pub fn get_public_key_from_proof_graph(
+        &self,
+        proof_graph: &Graph,
+    ) -> Result<BBSPlusPublicKey, RDFProofsError> {
+        let vm_triple = proof_graph
+            .triples_for_predicate(VERIFICATION_METHOD)
+            .next()
+            .ok_or(RDFProofsError::VerificationMethodNotFoundInProof)?;
+        self.get_public_key_from_vm_triple(vm_triple)
+    }
+
+    pub fn get_public_key_from_proof_graph_view(
+        &self,
+        proof_graph: &GraphView,
+    ) -> Result<BBSPlusPublicKey, RDFProofsError> {
+        let vm_triple = proof_graph
+            .triples_for_predicate(VERIFICATION_METHOD)
+            .next()
+            .ok_or(RDFProofsError::VerificationMethodNotFoundInProof)?;
+        self.get_public_key_from_vm_triple(vm_triple)
+    }
+
+    fn get_public_key_from_vm_triple(
+        &self,
+        vm_triple: TripleRef,
+    ) -> Result<BBSPlusPublicKey, RDFProofsError> {
+        let verification_method_identifier = match vm_triple.object {
+            TermRef::NamedNode(v) => Ok(v),
+            _ => Err(RDFProofsError::InvalidVerificationMethodURL),
+        }?;
+        self.get_public_key(verification_method_identifier)
     }
 
     pub fn get_keypair(
@@ -82,5 +115,199 @@ impl KeyGraph {
         let secret_key = self.get_secret_key(verification_method_identifier)?;
         let public_key = self.get_public_key(verification_method_identifier)?;
         Ok((secret_key, public_key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::{ark_to_base58btc, get_graph_from_ntriples};
+    use oxrdf::NamedNode;
+
+    const KEY_GRAPH: &str = r#"
+    # issuer0
+    <did:example:issuer0> <https://w3id.org/security#verificationMethod> <did:example:issuer0#bls12_381-g2-pub001> .
+    <did:example:issuer0#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
+    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer0> .
+    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z4893E1L7AeYfqaduUdLYgcxefWAah8gJB8RhPi7JHQkdRbe" .
+    <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC77BjGcGDVWfBdgzqwzp3uuWkoWuRMe8pnx4dkncia5t9LKHVt96BPGBizeSU7BKiV35h1tsuVwHUVt4arZuckxGCb2tTsB3fsY66mQNs5Bwoac2w2iyYFe8uenBUYdAiveEr" .
+    # issuer1
+    <did:example:issuer1> <https://w3id.org/security#verificationMethod> <did:example:issuer1#bls12_381-g2-pub001> .
+    <did:example:issuer1#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
+    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer1> .
+    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z488yTRFj1e7W6s6MVN6iYm6taiNByQwSCg2XwgEJvAcXr15" .
+    <did:example:issuer1#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC7HaSjNELSGG8QnYdMvNurgfWfdGNo1Znqds6CoYQ24qKKWogiLtKWPoCLJapEYdKAMN9r6bdF9MeNrfV3fhUzkKwrfUewD5yVhwSVpM4tjv87YVgWGRTUuesxf7scabbPAnD" .
+    # issuer2
+    <did:example:issuer2> <https://w3id.org/security#verificationMethod> <did:example:issuer2#bls12_381-g2-pub001> .
+    <did:example:issuer2#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
+    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer2> .
+    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z489AEiC5VbeLmVZxokiJYkXNZrMza9eCiPZ51ekgcV9mNvG" .
+    <did:example:issuer2#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC7DKvfSfydgg48FpP53HgsLfWrVHfrmUXbwvw8AnSgW1JiA5741mwe3hpMNNRMYh3BgR9ebxvGAxPxFhr8F3jQHZANqb3if2MycjQN3ZBSWP3aGoRyat294icdVMDhTqoKXeJ" .
+    # issuer3
+    <did:example:issuer3> <https://w3id.org/security#verificationMethod> <did:example:issuer3#bls12_381-g2-pub001> .
+    <did:example:issuer3#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
+    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer3> .
+    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z488w754KqucDkNxCWCoi5DkH6pvEt6aNZNYYYoKmDDx8m5G" .
+    <did:example:issuer3#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC74KLKQtdApVyY3EbAZfiW6A7HdwSZVLsBF2vs5512YwNWs5PRYiqavzWLoiAq6UcKLv6RAnUM9Y117Pg4LayaBMa9euz23C2TDtBq8QuhpbDRDqsjUxLS5S9ruWRk71SEo69" .
+    "#;
+
+    #[test]
+    fn get_keypair() {
+        let key_graph: KeyGraph = get_graph_from_ntriples(KEY_GRAPH).unwrap().into();
+
+        let verification_method_identifier =
+            NamedNode::new("did:example:issuer0#bls12_381-g2-pub001").unwrap();
+        let (secret_key, public_key) = key_graph
+            .get_keypair((&verification_method_identifier).into())
+            .expect("Failed to get keypair");
+
+        let secret_key_multibase =
+            ark_to_base58btc(&secret_key, crate::common::Multicodec::Bls12381G2Priv).unwrap();
+        assert_eq!(
+            secret_key_multibase,
+            "z4893E1L7AeYfqaduUdLYgcxefWAah8gJB8RhPi7JHQkdRbe"
+        );
+
+        let public_key_multibase =
+            ark_to_base58btc(&public_key, crate::common::Multicodec::Bls12381G2Pub).unwrap();
+        assert_eq!(
+            public_key_multibase,
+            "zUC77BjGcGDVWfBdgzqwzp3uuWkoWuRMe8pnx4dkncia5t9LKHVt96BPGBizeSU7BKiV35h1tsuVwHUVt4arZuckxGCb2tTsB3fsY66mQNs5Bwoac2w2iyYFe8uenBUYdAiveEr"
+        );
+    }
+
+    #[test]
+    fn verification_method_not_found() {
+        let key_graph: KeyGraph = get_graph_from_ntriples(KEY_GRAPH).unwrap().into();
+
+        let verification_method_identifier =
+            NamedNode::new("did:example:unknown-unknown-unknown").unwrap();
+        let result = key_graph.get_keypair((&verification_method_identifier).into());
+        assert!(matches!(
+            result,
+            Err(RDFProofsError::VerificationMethodNotFound)
+        ));
+    }
+
+    #[test]
+    fn verification_method_not_found_in_proof() {
+        const INVALID_PROOF: &str = r#"
+        _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#DataIntegrityProof> .
+        _:b0 <http://purl.org/dc/terms/created> "2023-02-09T09:35:07Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+        _:b0 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> .
+        # verification method does not exist
+        "#;
+
+        let key_graph: KeyGraph = get_graph_from_ntriples(KEY_GRAPH).unwrap().into();
+        let proof_graph: Graph = get_graph_from_ntriples(INVALID_PROOF).unwrap().into();
+        let result = key_graph.get_public_key_from_proof_graph(&proof_graph);
+
+        assert!(matches!(
+            result,
+            Err(RDFProofsError::VerificationMethodNotFoundInProof)
+        ));
+    }
+
+    #[test]
+    fn invalid_verification_method_url() {
+        const INVALID_PROOF: &str = r#"
+        _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#DataIntegrityProof> .
+        _:b0 <http://purl.org/dc/terms/created> "2023-02-09T09:35:07Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+        _:b0 <https://w3id.org/security#proofPurpose> <https://w3id.org/security#assertionMethod> .
+        _:b0 <https://w3id.org/security#verificationMethod> _:b0 .  # invalid URL
+        "#;
+
+        let key_graph: KeyGraph = get_graph_from_ntriples(KEY_GRAPH).unwrap().into();
+        let proof_graph: Graph = get_graph_from_ntriples(INVALID_PROOF).unwrap().into();
+        let result = key_graph.get_public_key_from_proof_graph(&proof_graph);
+
+        assert!(matches!(
+            result,
+            Err(RDFProofsError::InvalidVerificationMethodURL)
+        ));
+    }
+
+    #[test]
+    fn invalid_verification_method_secret_key() {
+        const INVALID_KEY_GRAPH: &str = r#"
+        <did:example:issuer0> <https://w3id.org/security#verificationMethod> <did:example:issuer0#bls12_381-g2-pub001> .
+        <did:example:issuer0#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
+        <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer0> .
+        <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> _:b0 .  # invalid key
+        <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC77BjGcGDVWfBdgzqwzp3uuWkoWuRMe8pnx4dkncia5t9LKHVt96BPGBizeSU7BKiV35h1tsuVwHUVt4arZuckxGCb2tTsB3fsY66mQNs5Bwoac2w2iyYFe8uenBUYdAiveEr" .
+        "#;
+
+        let key_graph: KeyGraph = get_graph_from_ntriples(INVALID_KEY_GRAPH).unwrap().into();
+
+        let verification_method_identifier =
+            NamedNode::new("did:example:issuer0#bls12_381-g2-pub001").unwrap();
+        let result = key_graph.get_keypair((&verification_method_identifier).into());
+        assert!(matches!(
+            result,
+            Err(RDFProofsError::InvalidVerificationMethodKey)
+        ));
+    }
+
+    #[test]
+    fn invalid_verification_method_public_key() {
+        const INVALID_KEY_GRAPH: &str = r#"
+        <did:example:issuer0> <https://w3id.org/security#verificationMethod> <did:example:issuer0#bls12_381-g2-pub001> .
+        <did:example:issuer0#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
+        <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer0> .
+        <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z4893E1L7AeYfqaduUdLYgcxefWAah8gJB8RhPi7JHQkdRbe" .
+        <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> _:b0 .  # invalid key
+        "#;
+
+        let key_graph: KeyGraph = get_graph_from_ntriples(INVALID_KEY_GRAPH).unwrap().into();
+
+        let verification_method_identifier =
+            NamedNode::new("did:example:issuer0#bls12_381-g2-pub001").unwrap();
+        let result = key_graph.get_keypair((&verification_method_identifier).into());
+        assert!(matches!(
+            result,
+            Err(RDFProofsError::InvalidVerificationMethodKey)
+        ));
+    }
+
+    #[test]
+    fn invalid_verification_method_codec_secret_key() {
+        const INVALID_KEY_GRAPH: &str = r#"
+        <did:example:issuer0> <https://w3id.org/security#verificationMethod> <did:example:issuer0#bls12_381-g2-pub001> .
+        <did:example:issuer0#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
+        <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer0> .
+        <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z9993E1L7AeYfqaduUdLYgcxefWAah8gJB8RhPi7JHQkdRbe" .  # invalid codec
+        <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "zUC77BjGcGDVWfBdgzqwzp3uuWkoWuRMe8pnx4dkncia5t9LKHVt96BPGBizeSU7BKiV35h1tsuVwHUVt4arZuckxGCb2tTsB3fsY66mQNs5Bwoac2w2iyYFe8uenBUYdAiveEr" .
+        "#;
+
+        let key_graph: KeyGraph = get_graph_from_ntriples(INVALID_KEY_GRAPH).unwrap().into();
+
+        let verification_method_identifier =
+            NamedNode::new("did:example:issuer0#bls12_381-g2-pub001").unwrap();
+        let result = key_graph.get_keypair((&verification_method_identifier).into());
+        assert!(matches!(
+            result,
+            Err(RDFProofsError::InvalidVerificationMethodKeyCodec)
+        ));
+    }
+
+    #[test]
+    fn invalid_verification_method_codec_public_key() {
+        const INVALID_KEY_GRAPH: &str = r#"
+        <did:example:issuer0> <https://w3id.org/security#verificationMethod> <did:example:issuer0#bls12_381-g2-pub001> .
+        <did:example:issuer0#bls12_381-g2-pub001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Multikey> .
+        <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#controller> <did:example:issuer0> .
+        <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#secretKeyMultibase> "z4893E1L7AeYfqaduUdLYgcxefWAah8gJB8RhPi7JHQkdRbe" .
+        <did:example:issuer0#bls12_381-g2-pub001> <https://w3id.org/security#publicKeyMultibase> "z9977BjGcGDVWfBdgzqwzp3uuWkoWuRMe8pnx4dkncia5t9LKHVt96BPGBizeSU7BKiV35h1tsuVwHUVt4arZuckxGCb2tTsB3fsY66mQNs5Bwoac2w2iyYFe8uenBUYdAiveEr" .  # invalid codec
+        "#;
+
+        let key_graph: KeyGraph = get_graph_from_ntriples(INVALID_KEY_GRAPH).unwrap().into();
+
+        let verification_method_identifier =
+            NamedNode::new("did:example:issuer0#bls12_381-g2-pub001").unwrap();
+        let result = key_graph.get_keypair((&verification_method_identifier).into());
+        assert!(matches!(
+            result,
+            Err(RDFProofsError::InvalidVerificationMethodKeyCodec)
+        ));
     }
 }

--- a/src/verify_proof.rs
+++ b/src/verify_proof.rs
@@ -134,7 +134,9 @@ pub fn verify_proof<R: RngCore>(
 
     // deserialize proof value into proof and index_map
     let (_, proof_value_bytes) = multibase::decode(proof_value_encoded)?;
-    let ProofWithIndexMap { proof, index_map } = serde_cbor::from_slice(&proof_value_bytes)?;
+    //let cursor = Cursor::new(proof_value_bytes);
+    let ProofWithIndexMap { proof, index_map } =
+        ciborium::de::from_reader(proof_value_bytes.as_slice())?;
     println!("proof:\n{:#?}\n", proof);
     println!("index_map:\n{:#?}\n", index_map);
 

--- a/src/verify_proof.rs
+++ b/src/verify_proof.rs
@@ -2,13 +2,13 @@ use crate::{
     common::{
         generate_proof_spec_context, get_dataset_from_nquads, get_delimiter,
         get_graph_from_ntriples, get_hasher, hash_term_to_field, is_nym, multibase_to_ark,
-        read_private_var_list, read_public_var_list, reorder_vc_triples, BBSPlusHash,
-        BBSPlusPublicKey, Fr, PedersenCommitmentStmt, PoKBBSPlusStmtVerifier, ProofWithIndexMap,
-        Statements, VerifyingKey,
+        read_private_var_list, read_public_var_list, reorder_vc_triples, BBSPlusHash, Fr,
+        PedersenCommitmentStmt, PoKBBSPlusStmtVerifier, ProofWithIndexMap, Statements,
+        VerifyingKey,
     },
     context::{
         CHALLENGE, CIRCUIT, DOMAIN, HOLDER, PREDICATE_TYPE, PRIVATE, PROOF_VALUE, PUBLIC,
-        SECRET_COMMITMENT, VERIFIABLE_PRESENTATION_TYPE, VERIFICATION_METHOD,
+        SECRET_COMMITMENT, VERIFIABLE_PRESENTATION_TYPE,
     },
     error::RDFProofsError,
     key_gen::{generate_params, PPID},
@@ -116,7 +116,7 @@ pub fn verify_proof<R: RngCore>(
     // get issuer public keys
     let public_keys = c14n_disclosed_vc_graphs
         .iter()
-        .map(|(_, vc)| get_public_keys_from_graphview(&vc.proof, key_graph))
+        .map(|(_, vc)| key_graph.get_public_key_from_proof_graph_view(&vc.proof))
         .collect::<Result<Vec<_>, _>>()?;
     println!("public_keys:\n{:#?}\n", public_keys);
 
@@ -519,20 +519,4 @@ fn build_disclosed_terms(
         None => {}
     };
     Ok(())
-}
-
-// TODO: to be integrated with `get_public_keys`
-fn get_public_keys_from_graphview(
-    proof_graph: &GraphView,
-    key_graph: &KeyGraph,
-) -> Result<BBSPlusPublicKey, RDFProofsError> {
-    let vm_triple = proof_graph
-        .triples_for_predicate(VERIFICATION_METHOD)
-        .next()
-        .ok_or(RDFProofsError::InvalidVerificationMethod)?;
-    let vm = match vm_triple.object {
-        TermRef::NamedNode(v) => Ok(v),
-        _ => Err(RDFProofsError::InvalidVerificationMethodURL),
-    }?;
-    key_graph.get_public_key(vm)
 }


### PR DESCRIPTION
### Added

- Added more detailed errors related to verification methods

### Changed

- Upgraded `oxrdf`, `oxttl`, `oxsdatatypes`, and `rdf-canon` dependencies, allowing us to remove the `alpha` tag from the version
- Upgraded `serde_cbor` to `ciborium` for CBOR serialization to resolve [RUSTSEC-2021-0127](https://rustsec.org/advisories/RUSTSEC-2021-0127)
- Refactored `KeyGraph` struct
