### PR TITLE
Add support for binary values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,6 @@ ark-bls12-381 = { version = "0.4", default-features = false, features = [
 ] }
 blake2 = { version = "0.10", default-features = false }
 sha2 = "0.10"
+num-bigint = "0.4.6"
+hex = "0.4.3"
+base64 = "0.22.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,7 +10,11 @@ use crate::{
 };
 use ark_bls12_381::{Bls12_381, G1Affine};
 use ark_ec::pairing::Pairing;
-use ark_ff::field_hashers::{DefaultFieldHasher, HashToField};
+use ark_ff::PrimeField;
+use ark_ff::{
+    field_hashers::{DefaultFieldHasher, HashToField},
+    BigInt,
+};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use base64::{prelude::BASE64_STANDARD, Engine};
 use bbs_plus::{
@@ -21,13 +25,12 @@ use blake2::Blake2b512;
 use chrono::{DateTime, NaiveDate, Utc};
 use legogroth16::circom::R1CS as R1CSOrig;
 use multibase::Base;
-use num_bigint::BigUint;
 use oxrdf::{
     dataset::GraphView,
     vocab::{
         self,
         rdf::{FIRST, NIL, REST, TYPE},
-        xsd::{self, BASE_64_BINARY, DATE, DATE_TIME, HEX_BINARY, INTEGER},
+        xsd::{self, DATE, DATE_TIME, INTEGER},
     },
     BlankNode, BlankNodeRef, Dataset, Graph, Literal, LiteralRef, NamedNode, NamedNodeRef,
     NamedOrBlankNode, SubjectRef, Term, TermRef, Triple, TripleRef,
@@ -288,6 +291,15 @@ pub fn hash_terms_to_field(
         .collect()
 }
 
+fn from_bytes_le(bytes: Vec<u8>) -> Vec<u64> {
+    assert!(bytes.len() % 8 == 0, "Byte length must be a multiple of 8");
+
+    bytes
+        .chunks_exact(8)
+        .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
+        .collect()
+}
+
 pub fn hash_term_to_field(
     term: TermRef,
     hasher: &BBSPlusDefaultFieldHasher,
@@ -298,18 +310,24 @@ pub fn hash_term_to_field(
             let num: i64 = v.value().parse()?;
             Ok(Fr::from(num))
         }
-        TermRef::Literal(v) if v.datatype() == HEX_BINARY => {
-            let bytes = hex::decode(v.value())
-                .map_err(|_| RDFProofsError::InvalidHexString(v.value().to_string()))?;
-            let num = BigUint::from_bytes_le(&bytes);
-            Ok(Fr::from(num))
+        TermRef::Literal(v) if v.datatype() == custom_vocab::BASE_64_BYTES_BE => {
+            let mut bytes = BASE64_STANDARD
+                .decode(v.value())
+                .map_err(|_| RDFProofsError::InvalidBase64String(v.value().to_string()))?;
+            bytes.reverse();
+            let num = BigInt::<4>::new(from_bytes_le(bytes).try_into().unwrap());
+            let fr = Fr::from(num);
+
+            Ok(fr)
         }
-        TermRef::Literal(v) if v.datatype() == BASE_64_BINARY => {
+        TermRef::Literal(v) if v.datatype() == custom_vocab::BASE_64_BYTES_LE => {
             let bytes = BASE64_STANDARD
                 .decode(v.value())
                 .map_err(|_| RDFProofsError::InvalidBase64String(v.value().to_string()))?;
-            let num = BigUint::from_bytes_le(&bytes);
-            Ok(Fr::from(num))
+
+            let num = BigInt::<4>::new(from_bytes_le(bytes).try_into().unwrap());
+            let fr = Fr::from_bigint(num).unwrap();
+            Ok(fr)
         }
         TermRef::Literal(v) if v.datatype() == DATE_TIME || v.datatype() == SCO_DATETIME => {
             let datetime: DateTime<Utc> = v.value().parse()?;
@@ -658,6 +676,11 @@ pub(crate) fn read_public_var_list(
         Some(TermRef::NamedNode(rest)) if rest == NIL => Ok(()),
         _ => Err(RDFProofsError::InvalidPredicate),
     }
+}
+
+pub mod custom_vocab {
+    pub const BASE_64_BYTES_BE: &str = "http://www.w3.org/2001/XMLSchema#base64BytesBe";
+    pub const BASE_64_BYTES_LE: &str = "http://www.w3.org/2001/XMLSchema#base64BytesLe";
 }
 
 #[cfg(test)]

--- a/src/derive_proof.rs
+++ b/src/derive_proof.rs
@@ -29,6 +29,8 @@ use crate::{
         VerifiableCredentialTriples, VerifiablePresentation,
     },
 };
+use ark_bls12_381::Config;
+use ark_ec::bls12::Bls12;
 use ark_std::rand::RngCore;
 use chrono::offset::Utc;
 use multibase::Base;
@@ -38,7 +40,7 @@ use oxrdf::{
     QuadRef, Subject, Term, TermRef, Triple,
 };
 use proof_system::{
-    prelude::{EqualWitnesses, MetaStatements},
+    prelude::{EqualWitnesses, MetaStatement, MetaStatements},
     proof_spec::ProofSpec,
     statement::r1cs_legogroth16::R1CSCircomProver,
     witness::{Witness, Witnesses},
@@ -58,6 +60,9 @@ pub fn derive_proof<R: RngCore>(
     with_ppid: Option<bool>,
     predicates: Vec<Graph>,
     circuits: HashMap<NamedNode, Circuit>,
+    statements: Option<Statements>,
+    meta_statements: Option<MetaStatements>,
+    witnesses: Option<Witnesses<Bls12<Config>>>,
 ) -> Result<Dataset, RDFProofsError> {
     for vc in vc_pairs {
         println!("{}", vc.to_string());
@@ -246,6 +251,19 @@ pub fn derive_proof<R: RngCore>(
         );
     }
 
+    // vc reorder map
+    let vc_reorder_map = {
+        let mut map = BTreeMap::<usize, usize>::new();
+        for (orig_i, vc) in canonicalized_original_vcs.iter().enumerate() {
+            let sort_i = original_vc_vec
+                .iter()
+                .position(|v| Graph::from_iter(v.document.iter().cloned()) == vc.document)
+                .ok_or(RDFProofsError::MalformedProof)?;
+            map.insert(orig_i, sort_i);
+        }
+        map
+    };
+
     // generate index map
     let index_map = gen_index_map(&original_vc_vec, &disclosed_vc_vec, &extended_deanon_map)?;
     println!("index_map:\n{:#?}\n", index_map);
@@ -260,6 +278,7 @@ pub fn derive_proof<R: RngCore>(
         public_keys,
         vc_proof_values_vec,
         index_map,
+        vc_reorder_map,
         &vp_draft,
         challenge,
         &blind_sign_request,
@@ -267,6 +286,9 @@ pub fn derive_proof<R: RngCore>(
         predicate_graphs,
         circuits,
         &extended_deanon_map,
+        statements.unwrap_or(Statements::new()),
+        meta_statements.unwrap_or(MetaStatements::new()),
+        witnesses.unwrap_or(Witnesses::new()),
     )?;
 
     // add derived proof value to VP
@@ -297,6 +319,9 @@ pub fn derive_proof_string<R: RngCore>(
     with_ppid: Option<bool>,
     predicates: Option<&Vec<String>>,
     circuits: Option<&HashMap<String, CircuitString>>,
+    statements: Option<Statements>,
+    meta_statements: Option<MetaStatements>,
+    witnesses: Option<Witnesses<Bls12<Config>>>,
 ) -> Result<String, RDFProofsError> {
     // construct inputs for `derive_proof` from string-based inputs
     let vc_pairs = vc_pairs
@@ -358,6 +383,9 @@ pub fn derive_proof_string<R: RngCore>(
         with_ppid,
         predicates,
         circuits,
+        statements,
+        meta_statements,
+        witnesses,
     )?;
 
     Ok(rdf_canon::serialize(&derived_proof))
@@ -916,6 +944,7 @@ fn derive_proof_value<R: RngCore>(
     public_keys: Vec<BBSPlusPublicKey>,
     proof_values: Vec<String>,
     index_map: Vec<StatementIndexMap>,
+    vc_reorder_map: BTreeMap<usize, usize>,
     canonicalized_vp: &Dataset,
     challenge: Option<&str>,
     blind_sign_request: &Option<BlindSignRequest>,
@@ -923,6 +952,9 @@ fn derive_proof_value<R: RngCore>(
     predicate_graphs: OrderedGraphViews,
     circuits: HashMap<NamedNode, Circuit>,
     extended_deanon_map: &HashMap<NamedOrBlankNode, Term>,
+    statements_pass: Statements,
+    meta_statements_pass: MetaStatements,
+    witnesses_pass: Witnesses<Bls12<Config>>,
 ) -> Result<String, RDFProofsError> {
     let hasher = get_hasher();
 
@@ -993,6 +1025,7 @@ fn derive_proof_value<R: RngCore>(
 
     // build statements
     let mut statements = Statements::new();
+
     // statements for BBS+ signatures
     for (DisclosedAndUndisclosedTerms { disclosed, .. }, (params, _public_key)) in
         disclosed_and_undisclosed_terms.iter().zip(params_and_pks)
@@ -1002,6 +1035,8 @@ fn derive_proof_value<R: RngCore>(
             disclosed.clone(),
         ));
     }
+    let num_sigs = statements.len();
+
     // statement for PPID
     let mut ppid_index = None;
     if let Some(ppid) = ppid {
@@ -1114,8 +1149,6 @@ fn derive_proof_value<R: RngCore>(
 
     // build proof spec
     let context = generate_proof_spec_context(&canonicalized_vp, &index_map)?;
-    let proof_spec = ProofSpec::new(statements, meta_statements, vec![], Some(context));
-    proof_spec.validate()?;
 
     // build witnesses
     let mut witnesses = Witnesses::new();
@@ -1175,6 +1208,44 @@ fn derive_proof_value<R: RngCore>(
         witnesses.add(Witness::R1CSLegoGroth16(r1cs_wit));
     }
     println!("witnesses:\n{:#?}\n", witnesses);
+
+    // add the passed parameters
+    meta_statements.0.extend_from_slice(
+        &meta_statements_pass
+            .0
+            .iter()
+            .cloned()
+            .map(|m| match m {
+                MetaStatement::WitnessEquality(eq) => {
+                    MetaStatement::WitnessEquality(EqualWitnesses(
+                        eq.0.iter()
+                            .cloned()
+                            // "shift" the index by the amount of other statements that are added.
+                            // This is statements.len() - 1 as the pok_sig statement is always
+                            // added and already accounted for.
+                            //
+                            // Statement index 0 is reserved for pok_sig
+                            .map(|(s, w)| {
+                                (
+                                    if s < num_sigs {
+                                        vc_reorder_map[&s]
+                                    } else {
+                                        s + statements.len() - num_sigs
+                                    },
+                                    w,
+                                )
+                            })
+                            .collect(),
+                    ))
+                }
+            })
+            .collect::<Vec<_>>(),
+    );
+    statements.0.extend_from_slice(&statements_pass.0);
+    witnesses.0.extend_from_slice(&witnesses_pass.0);
+
+    let proof_spec = ProofSpec::new(statements, meta_statements, vec![], Some(context));
+    proof_spec.validate()?;
 
     // build proof
     let proof = Proof::new::<R, BBSPlusHash>(
@@ -1624,6 +1695,9 @@ mod tests {
             None,
             vec![],
             HashMap::new(),
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derived_proof.vp: {}", rdf_canon::serialize(&derived_proof));
@@ -1635,6 +1709,8 @@ mod tests {
             Some(challenge),
             None,
             HashMap::new(),
+            None,
+            None,
         );
         assert!(verified.is_ok(), "{:?}", verified)
     }
@@ -1664,6 +1740,9 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derived_proof: {}", derived_proof);
@@ -1673,6 +1752,8 @@ mod tests {
             &derived_proof,
             KEY_GRAPH,
             Some(challenge),
+            None,
+            None,
             None,
             None,
         );
@@ -1692,6 +1773,8 @@ mod tests {
             Some(challenge),
             None,
             HashMap::new(),
+            None,
+            None,
         );
         assert!(verified.is_ok(), "{:?}", verified)
     }
@@ -1700,7 +1783,16 @@ mod tests {
     fn verify_proof_string_success() {
         let mut rng = StdRng::seed_from_u64(0u64); // TODO: to be fixed
         let challenge = "abcde";
-        let verified = verify_proof_string(&mut rng, VP, KEY_GRAPH, Some(challenge), None, None);
+        let verified = verify_proof_string(
+            &mut rng,
+            VP,
+            KEY_GRAPH,
+            Some(challenge),
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(verified.is_ok(), "{:?}", verified)
     }
 
@@ -1746,6 +1838,9 @@ mod tests {
             None,
             vec![],
             HashMap::new(),
+            None,
+            None,
+            None,
         )
         .unwrap();
         assert!(verify_proof(
@@ -1754,7 +1849,9 @@ mod tests {
             &key_graph,
             challenge,
             domain,
-            HashMap::new()
+            HashMap::new(),
+            None,
+            None,
         )
         .is_ok());
         assert!(matches!(
@@ -1764,7 +1861,9 @@ mod tests {
                 &key_graph,
                 None,
                 domain,
-                HashMap::new()
+                HashMap::new(),
+                None,
+                None,
             ),
             Err(RDFProofsError::MissingChallengeInRequest)
         ));
@@ -1775,7 +1874,9 @@ mod tests {
                 &key_graph,
                 challenge,
                 None,
-                HashMap::new()
+                HashMap::new(),
+                None,
+                None,
             ),
             Err(RDFProofsError::MissingDomainInRequest)
         ));
@@ -1786,7 +1887,9 @@ mod tests {
                 &key_graph,
                 None,
                 None,
-                HashMap::new()
+                HashMap::new(),
+                None,
+                None,
             ),
             Err(RDFProofsError::MissingChallengeInRequest)
         ));
@@ -1803,63 +1906,9 @@ mod tests {
             None,
             vec![],
             HashMap::new(),
-        )
-        .unwrap();
-        assert!(matches!(
-            verify_proof(
-                &mut rng,
-                &derived_proof,
-                &key_graph,
-                challenge,
-                domain,
-                HashMap::new()
-            ),
-            Err(RDFProofsError::MissingChallengeInVP)
-        ));
-        assert!(verify_proof(
-            &mut rng,
-            &derived_proof,
-            &key_graph,
-            None,
-            domain,
-            HashMap::new()
-        )
-        .is_ok());
-        assert!(matches!(
-            verify_proof(
-                &mut rng,
-                &derived_proof,
-                &key_graph,
-                challenge,
-                None,
-                HashMap::new()
-            ),
-            Err(RDFProofsError::MissingChallengeInVP)
-        ));
-        assert!(matches!(
-            verify_proof(
-                &mut rng,
-                &derived_proof,
-                &key_graph,
-                None,
-                None,
-                HashMap::new()
-            ),
-            Err(RDFProofsError::MissingDomainInRequest)
-        ));
-
-        let derived_proof = derive_proof(
-            &mut rng,
-            &vcs,
-            &deanon_map,
-            &key_graph,
-            challenge,
             None,
             None,
             None,
-            None,
-            vec![],
-            HashMap::new(),
         )
         .unwrap();
         assert!(matches!(
@@ -1870,6 +1919,76 @@ mod tests {
                 challenge,
                 domain,
                 HashMap::new(),
+                None,
+                None,
+            ),
+            Err(RDFProofsError::MissingChallengeInVP)
+        ));
+        assert!(verify_proof(
+            &mut rng,
+            &derived_proof,
+            &key_graph,
+            None,
+            domain,
+            HashMap::new(),
+            None,
+            None,
+        )
+        .is_ok());
+        assert!(matches!(
+            verify_proof(
+                &mut rng,
+                &derived_proof,
+                &key_graph,
+                challenge,
+                None,
+                HashMap::new(),
+                None,
+                None,
+            ),
+            Err(RDFProofsError::MissingChallengeInVP)
+        ));
+        assert!(matches!(
+            verify_proof(
+                &mut rng,
+                &derived_proof,
+                &key_graph,
+                None,
+                None,
+                HashMap::new(),
+                None,
+                None,
+            ),
+            Err(RDFProofsError::MissingDomainInRequest)
+        ));
+
+        let derived_proof = derive_proof(
+            &mut rng,
+            &vcs,
+            &deanon_map,
+            &key_graph,
+            challenge,
+            None,
+            None,
+            None,
+            None,
+            vec![],
+            HashMap::new(),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(matches!(
+            verify_proof(
+                &mut rng,
+                &derived_proof,
+                &key_graph,
+                challenge,
+                domain,
+                HashMap::new(),
+                None,
+                None,
             ),
             Err(RDFProofsError::MissingDomainInVP)
         ));
@@ -1880,7 +1999,9 @@ mod tests {
                 &key_graph,
                 None,
                 domain,
-                HashMap::new()
+                HashMap::new(),
+                None,
+                None,
             ),
             Err(RDFProofsError::MissingChallengeInRequest)
         ));
@@ -1890,7 +2011,9 @@ mod tests {
             &key_graph,
             challenge,
             None,
-            HashMap::new()
+            HashMap::new(),
+            None,
+            None,
         )
         .is_ok());
         assert!(matches!(
@@ -1900,7 +2023,9 @@ mod tests {
                 &key_graph,
                 None,
                 None,
-                HashMap::new()
+                HashMap::new(),
+                None,
+                None,
             ),
             Err(RDFProofsError::MissingChallengeInRequest)
         ));
@@ -1917,6 +2042,9 @@ mod tests {
             None,
             vec![],
             HashMap::new(),
+            None,
+            None,
+            None,
         )
         .unwrap();
         assert!(matches!(
@@ -1926,7 +2054,9 @@ mod tests {
                 &key_graph,
                 challenge,
                 domain,
-                HashMap::new()
+                HashMap::new(),
+                None,
+                None,
             ),
             Err(RDFProofsError::MissingChallengeInVP)
         ));
@@ -1937,7 +2067,9 @@ mod tests {
                 &key_graph,
                 None,
                 domain,
-                HashMap::new()
+                HashMap::new(),
+                None,
+                None,
             ),
             Err(RDFProofsError::MissingDomainInVP)
         ));
@@ -1948,7 +2080,9 @@ mod tests {
                 &key_graph,
                 challenge,
                 None,
-                HashMap::new()
+                HashMap::new(),
+                None,
+                None,
             ),
             Err(RDFProofsError::MissingChallengeInVP)
         ));
@@ -1958,7 +2092,9 @@ mod tests {
             &key_graph,
             None,
             None,
-            HashMap::new()
+            HashMap::new(),
+            None,
+            None,
         )
         .is_ok());
     }
@@ -1989,22 +2125,59 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
-        assert!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, challenge, domain, None)
-                .is_ok()
-        );
+        assert!(verify_proof_string(
+            &mut rng,
+            &derived_proof,
+            KEY_GRAPH,
+            challenge,
+            domain,
+            None,
+            None,
+            None,
+        )
+        .is_ok());
         assert!(matches!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, None, domain, None),
+            verify_proof_string(
+                &mut rng,
+                &derived_proof,
+                KEY_GRAPH,
+                None,
+                domain,
+                None,
+                None,
+                None,
+            ),
             Err(RDFProofsError::MissingChallengeInRequest)
         ));
         assert!(matches!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, challenge, None, None),
+            verify_proof_string(
+                &mut rng,
+                &derived_proof,
+                KEY_GRAPH,
+                challenge,
+                None,
+                None,
+                None,
+                None,
+            ),
             Err(RDFProofsError::MissingDomainInRequest)
         ));
         assert!(matches!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, None, None, None),
+            verify_proof_string(
+                &mut rng,
+                &derived_proof,
+                KEY_GRAPH,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
             Err(RDFProofsError::MissingChallengeInRequest)
         ));
 
@@ -2020,21 +2193,59 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
         assert!(matches!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, challenge, domain, None),
+            verify_proof_string(
+                &mut rng,
+                &derived_proof,
+                KEY_GRAPH,
+                challenge,
+                domain,
+                None,
+                None,
+                None,
+            ),
             Err(RDFProofsError::MissingChallengeInVP)
         ));
-        assert!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, None, domain, None).is_ok()
-        );
+        assert!(verify_proof_string(
+            &mut rng,
+            &derived_proof,
+            KEY_GRAPH,
+            None,
+            domain,
+            None,
+            None,
+            None,
+        )
+        .is_ok());
         assert!(matches!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, challenge, None, None),
+            verify_proof_string(
+                &mut rng,
+                &derived_proof,
+                KEY_GRAPH,
+                challenge,
+                None,
+                None,
+                None,
+                None,
+            ),
             Err(RDFProofsError::MissingChallengeInVP)
         ));
         assert!(matches!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, None, None, None),
+            verify_proof_string(
+                &mut rng,
+                &derived_proof,
+                KEY_GRAPH,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
             Err(RDFProofsError::MissingDomainInRequest)
         ));
 
@@ -2050,21 +2261,59 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
         assert!(matches!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, challenge, domain, None),
+            verify_proof_string(
+                &mut rng,
+                &derived_proof,
+                KEY_GRAPH,
+                challenge,
+                domain,
+                None,
+                None,
+                None,
+            ),
             Err(RDFProofsError::MissingDomainInVP)
         ));
         assert!(matches!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, None, domain, None),
+            verify_proof_string(
+                &mut rng,
+                &derived_proof,
+                KEY_GRAPH,
+                None,
+                domain,
+                None,
+                None,
+                None,
+            ),
             Err(RDFProofsError::MissingChallengeInRequest)
         ));
-        assert!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, challenge, None, None).is_ok()
-        );
+        assert!(verify_proof_string(
+            &mut rng,
+            &derived_proof,
+            KEY_GRAPH,
+            challenge,
+            None,
+            None,
+            None,
+            None,
+        )
+        .is_ok());
         assert!(matches!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, None, None, None),
+            verify_proof_string(
+                &mut rng,
+                &derived_proof,
+                KEY_GRAPH,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
             Err(RDFProofsError::MissingChallengeInRequest)
         ));
 
@@ -2080,21 +2329,61 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
         assert!(matches!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, challenge, domain, None),
+            verify_proof_string(
+                &mut rng,
+                &derived_proof,
+                KEY_GRAPH,
+                challenge,
+                domain,
+                None,
+                None,
+                None,
+            ),
             Err(RDFProofsError::MissingChallengeInVP)
         ));
         assert!(matches!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, None, domain, None),
+            verify_proof_string(
+                &mut rng,
+                &derived_proof,
+                KEY_GRAPH,
+                None,
+                domain,
+                None,
+                None,
+                None,
+            ),
             Err(RDFProofsError::MissingDomainInVP)
         ));
         assert!(matches!(
-            verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, challenge, None, None),
+            verify_proof_string(
+                &mut rng,
+                &derived_proof,
+                KEY_GRAPH,
+                challenge,
+                None,
+                None,
+                None,
+                None,
+            ),
             Err(RDFProofsError::MissingChallengeInVP)
         ));
-        assert!(verify_proof_string(&mut rng, &derived_proof, KEY_GRAPH, None, None, None).is_ok());
+        assert!(verify_proof_string(
+            &mut rng,
+            &derived_proof,
+            KEY_GRAPH,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .is_ok());
     }
 
     const DISCLOSED_VC_1_WITH_HIDDEN_LITERALS: &str = r#"
@@ -2163,6 +2452,9 @@ mod tests {
             None,
             vec![],
             HashMap::new(),
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derived_proof: {}", rdf_canon::serialize(&derived_proof));
@@ -2174,6 +2466,8 @@ mod tests {
             Some(challenge),
             None,
             HashMap::new(),
+            None,
+            None,
         );
         assert!(verified.is_ok(), "{:?}", verified)
     }
@@ -2206,6 +2500,9 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
 
@@ -2214,6 +2511,8 @@ mod tests {
             &derived_proof,
             KEY_GRAPH,
             Some(challenge),
+            None,
+            None,
             None,
             None,
         );
@@ -2272,6 +2571,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             vec![],
             HashMap::new(),
+            None,
+            None,
+            None,
         );
         assert!(matches!(
             derived_proof,
@@ -2302,6 +2604,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             &deanon_map,
             KEY_GRAPH,
             Some(challenge),
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -2366,6 +2671,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
 
@@ -2374,6 +2682,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             &derived_proof,
             KEY_GRAPH,
             Some(challenge),
+            None,
+            None,
             None,
             None,
         );
@@ -2412,6 +2722,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             None,
+            None,
+            None,
+            None,
         );
         assert!(matches!(
             derived_proof,
@@ -2445,6 +2758,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             &deanon_map,
             KEY_GRAPH,
             Some(challenge),
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -2566,6 +2882,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derived_proof: {}", derived_proof);
@@ -2575,6 +2894,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             &derived_proof,
             KEY_GRAPH,
             Some(challenge),
+            None,
+            None,
             None,
             None,
         );
@@ -2657,6 +2978,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             None,
+            None,
+            None,
+            None,
         );
         assert!(derived_proof.is_err(), "{:?}", derived_proof)
     }
@@ -2715,6 +3039,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
 
@@ -2723,6 +3050,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             &derived_proof,
             KEY_GRAPH,
             Some(challenge),
+            None,
+            None,
             None,
             None,
         );
@@ -2750,6 +3079,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
 
@@ -2758,6 +3090,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             &derived_proof,
             KEY_GRAPH,
             Some(challenge),
+            None,
+            None,
             None,
             None,
         );
@@ -2797,6 +3131,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             Some(true),
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derived_proof:\n{}", derived_proof);
@@ -2807,6 +3144,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             KEY_GRAPH,
             Some(challenge),
             Some(domain),
+            None,
+            None,
             None,
         );
         assert!(verified.is_ok(), "{:?}", verified)
@@ -2833,6 +3172,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             Some(true),
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derived_proof:\n{}", derived_proof);
@@ -2843,6 +3185,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             KEY_GRAPH,
             Some(challenge),
             Some(domain),
+            None,
+            None,
             None,
         );
         assert!(verified.is_ok(), "{:?}", verified)
@@ -2867,6 +3211,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             Some(secret),
             None,
             Some(false),
+            None,
+            None,
+            None,
             None,
             None,
         );
@@ -2910,6 +3257,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             Some(true),
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
 
@@ -2919,6 +3269,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             KEY_GRAPH,
             Some(challenge),
             Some(domain),
+            None,
+            None,
             None,
         );
         assert!(verified.is_ok(), "{:?}", verified)
@@ -3033,6 +3385,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             Some(&predicates),
             Some(&circuit),
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derive_proof: {}", derived_proof);
@@ -3049,6 +3404,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             Some(snark_verifying_keys.clone()),
+            None,
+            None,
         );
         assert!(verified.is_ok(), "{:?}", verified);
 
@@ -3083,6 +3440,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             Some(&predicates_same_datetime),
             Some(&circuit),
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derive_proof: {}", derived_proof);
@@ -3093,6 +3453,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             Some(snark_verifying_keys),
+            None,
+            None,
         );
         assert!(matches!(
             verified,
@@ -3175,6 +3537,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             Some(&predicates),
             Some(&circuit),
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derive_proof: {}", derived_proof);
@@ -3191,6 +3556,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             Some(snark_verifying_keys.clone()),
+            None,
+            None,
         );
         assert!(verified.is_ok(), "{:?}", verified);
 
@@ -3225,6 +3592,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             Some(&predicates_lesser_datetime),
             Some(&circuit),
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derive_proof: {}", derived_proof);
@@ -3235,6 +3605,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             Some(snark_verifying_keys),
+            None,
+            None,
         );
         assert!(matches!(
             verified,
@@ -3369,6 +3741,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             Some(&predicates),
             Some(&circuit),
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derive_proof: {}", derived_proof);
@@ -3385,6 +3760,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             Some(snark_verifying_keys.clone()),
+            None,
+            None,
         );
         assert!(verified.is_ok(), "{:?}", verified);
 
@@ -3419,6 +3796,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             Some(&predicates_lesser_datetime),
             Some(&circuit),
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derive_proof: {}", derived_proof);
@@ -3429,6 +3809,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             Some(snark_verifying_keys),
+            None,
+            None,
         );
         assert!(matches!(
             verified,
@@ -3559,6 +3941,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             Some(&predicates),
             Some(&circuit),
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derive_proof: {}", derived_proof);
@@ -3575,6 +3960,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             Some(snark_verifying_keys.clone()),
+            None,
+            None,
         );
         assert!(verified.is_ok(), "{:?}", verified);
 
@@ -3610,6 +3997,9 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             Some(&predicates_same_integer),
             Some(&circuit),
+            None,
+            None,
+            None,
         )
         .unwrap();
         println!("derive_proof: {}", derived_proof);
@@ -3620,6 +4010,8 @@ _:b1 <http://schema.org/name> "ABC inc." .
             None,
             None,
             Some(snark_verifying_keys),
+            None,
+            None,
         );
         assert!(matches!(
             verified,

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,8 @@ pub enum RDFProofsError {
     MissingPredicateCircuit,
     MissingSnarkVK(String),
     InvalidInteger(String),
+    InvalidHexString(String),
+    InvalidBase64String(String),
     InvalidDateTime(String),
     DateTimeParse(chrono::ParseError),
     ParseInt(std::num::ParseIntError),
@@ -202,6 +204,8 @@ impl std::fmt::Display for RDFProofsError {
                     v
                 )
             }
+            RDFProofsError::InvalidHexString(e) => write!(f, "hex parse error: {}", e),
+            RDFProofsError::InvalidBase64String(e) => write!(f, "base64 parse error: {}", e),
             RDFProofsError::DateTimeParse(e) => write!(f, "date time parse error: {}", e),
             RDFProofsError::ParseInt(e) => write!(f, "parse int error: {}", e),
             RDFProofsError::Circom(e) => write!(f, "circom error: {:?}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub mod key_gen;
 mod key_graph;
 mod ordered_triple;
 mod predicate;
-mod signature;
+pub mod signature;
 mod vc;
 mod verify_proof;
 
@@ -17,11 +17,16 @@ pub use blind_signature::{
     request_blind_sign_string, unblind, unblind_string, verify_blind_sign_request,
     verify_blind_sign_request_string, BlindSignRequest, BlindSignRequestString,
 };
-pub use common::{ark_to_base64url, ark_to_multibase, multibase_to_ark};
+pub use common::{
+    ark_to_base64url, ark_to_multibase, custom_vocab as vocab, multibase_to_ark,
+    reorder_vc_triples, ProofWithIndexMap,
+};
 pub use derive_proof::{derive_proof, derive_proof_string};
 pub use key_gen::KeyPairBase58Btc;
 pub use key_graph::KeyGraph;
-pub use predicate::CircuitString;
+pub use predicate::{Circuit, CircuitString};
 pub use signature::{sign, sign_string, verify, verify_string};
-pub use vc::{VcPair, VcPairString, VerifiableCredential};
+pub use vc::{
+    VcPair, VcPairString, VerifiableCredential, VerifiableCredentialTriples, VerifiablePresentation,
+};
 pub use verify_proof::{verify_proof, verify_proof_string};

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -78,7 +78,7 @@ pub fn verify_string(document: &str, proof: &str, key_graph: &str) -> Result<(),
     verify(&vc, &key_graph)
 }
 
-pub(crate) fn transform(graph: &Graph) -> Result<Vec<Term>, RDFProofsError> {
+pub fn transform(graph: &Graph) -> Result<Vec<Term>, RDFProofsError> {
     canonicalize_graph_into_terms(graph)
 }
 

--- a/src/verify_proof.rs
+++ b/src/verify_proof.rs
@@ -23,7 +23,7 @@ use oxrdf::{
     NamedOrBlankNodeRef, Subject, Term, TermRef, Triple,
 };
 use proof_system::{
-    prelude::{EqualWitnesses, MetaStatements},
+    prelude::{EqualWitnesses, MetaStatement, MetaStatements},
     proof_spec::ProofSpec,
     statement::r1cs_legogroth16::R1CSCircomVerifier,
 };
@@ -37,6 +37,8 @@ pub fn verify_proof<R: RngCore>(
     challenge: Option<&str>,
     domain: Option<&str>,
     snark_verifying_keys: HashMap<NamedNode, VerifyingKey>,
+    statements_pass: Option<Statements>,
+    meta_statements_pass: Option<MetaStatements>,
 ) -> Result<(), RDFProofsError> {
     let hasher = get_hasher();
 
@@ -186,9 +188,8 @@ pub fn verify_proof<R: RngCore>(
                 .extend(v.clone());
         }
     }
-
-    // build statements
     let mut statements = Statements::new();
+
     // statements for BBS+ signatures
     for (DisclosedTerms { disclosed, .. }, (params, public_key)) in
         disclosed_terms.iter().zip(params_and_pks)
@@ -199,6 +200,7 @@ pub fn verify_proof<R: RngCore>(
             disclosed.clone(),
         ));
     }
+    let num_sigs = statements.len();
     // statement for PPID
     let mut ppid_index = None;
     if let Some(ppid) = ppid {
@@ -321,6 +323,44 @@ pub fn verify_proof<R: RngCore>(
         return Err(RDFProofsError::NoStatementsToVerify);
     }
 
+    // add the passed parameters
+    if let Some(meta_statements_pass) = meta_statements_pass {
+        meta_statements.0.extend_from_slice(
+            &meta_statements_pass
+                .0
+                .iter()
+                .cloned()
+                .map(|m| match m {
+                    MetaStatement::WitnessEquality(eq) => {
+                        MetaStatement::WitnessEquality(EqualWitnesses(
+                            eq.0.iter()
+                                .cloned()
+                                // "shift" the index by the amount of other statements that are added.
+                                // This is statements.len() - 1 as the pok_sig statement is always
+                                // added and already accounted for.
+                                //
+                                // Statement index 0 is reserved for pok_sig
+                                .map(|(s, w)| {
+                                    (
+                                        if s < num_sigs {
+                                            s
+                                        } else {
+                                            s + statements.len() - num_sigs
+                                        },
+                                        w,
+                                    )
+                                })
+                                .collect(),
+                        ))
+                    }
+                })
+                .collect::<Vec<_>>(),
+        );
+    }
+    if let Some(statements_pass) = statements_pass {
+        statements.0.extend_from_slice(&statements_pass.0);
+    }
+
     // build proof spec
     let context = generate_proof_spec_context(&canonicalized_vp, &index_map)?;
     let proof_spec = ProofSpec::new(statements, meta_statements, vec![], Some(context));
@@ -342,6 +382,8 @@ pub fn verify_proof_string<R: RngCore>(
     challenge: Option<&str>,
     domain: Option<&str>,
     snark_verifying_keys: Option<HashMap<String, String>>,
+    statements: Option<Statements>,
+    meta_statements: Option<MetaStatements>,
 ) -> Result<(), RDFProofsError> {
     // construct input for `verify_proof` from string-based input
     let vp = get_dataset_from_nquads(vp)?;
@@ -354,7 +396,16 @@ pub fn verify_proof_string<R: RngCore>(
             .collect::<Result<HashMap<_, VerifyingKey>, RDFProofsError>>()?,
     };
 
-    verify_proof(rng, &vp, &key_graph, challenge, domain, snark_verifying_key)
+    verify_proof(
+        rng,
+        &vp,
+        &key_graph,
+        challenge,
+        domain,
+        snark_verifying_key,
+        statements,
+        meta_statements,
+    )
 }
 
 fn get_ppid(metadata: &GraphView, domain: &str) -> Result<Option<PPID>, RDFProofsError> {


### PR DESCRIPTION
For more complex proofs, being able to control the binary representation of a message is necessary. This PR adds support for that by storing the bytes of a value directly in the message if the datatype is either `HEX_BINARY` or `BASE_64_BINARY`.